### PR TITLE
added description field to the post object and pgPost object

### DIFF
--- a/SharpSite.Abstractions/Post.cs
+++ b/SharpSite.Abstractions/Post.cs
@@ -14,6 +14,9 @@ public class Post
 		[Required, MaxLength(200)]
 		public required string Title { get; set; } = string.Empty;
 
+		[MaxLength(500)]
+		public string? Description { get; set; }
+
 		[Required]
 		public required string Content { get; set; } = string.Empty;
 

--- a/SharpSite.Data.Postgres/Migrations/20241029161246_Add description to post.Designer.cs
+++ b/SharpSite.Data.Postgres/Migrations/20241029161246_Add description to post.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SharpSite.Data.Postgres;
@@ -11,9 +12,11 @@ using SharpSite.Data.Postgres;
 namespace SharpSite.Data.Postgres.Migrations
 {
     [DbContext(typeof(PgContext))]
-    partial class PgContextModelSnapshot : ModelSnapshot
+    [Migration("20241029161246_Add description to post")]
+    partial class Adddescriptiontopost
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/SharpSite.Data.Postgres/Migrations/20241029161246_Add description to post.cs
+++ b/SharpSite.Data.Postgres/Migrations/20241029161246_Add description to post.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SharpSite.Data.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class Adddescriptiontopost : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Description",
+                table: "Posts",
+                type: "character varying(500)",
+                maxLength: 500,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Description",
+                table: "Posts");
+        }
+    }
+}

--- a/SharpSite.Data.Postgres/PgPost.cs
+++ b/SharpSite.Data.Postgres/PgPost.cs
@@ -14,6 +14,9 @@ public class PgPost
 	[Required, MaxLength(200)]
 	public required string Title { get; set; }
 
+	[MaxLength(500)]
+	public string? Description { get; set; }
+
 	[Required]
 	public required string Content { get; set; } = string.Empty;
 
@@ -27,6 +30,7 @@ public class PgPost
 		{
 			Slug = post.Slug,
 			Title = post.Title,
+			Description = post.Description,
 			Content = post.Content,
 			Published = post.PublishedDate
 		};
@@ -40,6 +44,7 @@ public class PgPost
 		{
 			Slug = post.Slug,
 			Title = post.Title,
+			Description = post.Description,
 			Content = post.Content,
 			PublishedDate = post.Published
 		};

--- a/SharpSite.Web/Components/Admin/EditPost.razor
+++ b/SharpSite.Web/Components/Admin/EditPost.razor
@@ -31,6 +31,12 @@
 	<input type="date" class="form-control" id="publishDate" @bind="Post.PublishedDate" />
 </div>
 
+@** add a textarea for the Post description *@
+<div class="form-group">
+	<label for="description">Description</label>
+	<textarea class="form-control" id="description" rows="3" @bind="Post.Description"></textarea>
+</div>
+
 <div class="form-group">
 	<label for="content">Content</label>
 	<TextEditor @bind-Content="@Post.Content" />

--- a/SharpSite.Web/Components/PostView.razor
+++ b/SharpSite.Web/Components/PostView.razor
@@ -1,6 +1,7 @@
 <h2><a href="@item.ToUrl()">@item.Title</a></h2>
 <h4>@item.PublishedDate.LocalDateTime.ToShortDateString()</h4>
 
+<p>@item.Description</p>
 
 @code {
 	[Parameter, EditorRequired] 


### PR DESCRIPTION
fixes #38 

This pull request introduces a new `Description` field to the `Post` class and updates various parts of the codebase to support this new field. The most important changes include modifications to the `Post` and `PgPost` classes, database migrations, and updates to the front-end components to handle the new `Description` field.

### Changes to Data Models:

* [`SharpSite.Abstractions/Post.cs`](diffhunk://#diff-8981207fc5d7893345c33f4e0edb9207e60ce4aad8563d33ff65661675bd6676R17-R19): Added a nullable `Description` property with a maximum length of 500 characters to the `Post` class.
* [`SharpSite.Data.Postgres/PgPost.cs`](diffhunk://#diff-c2951412032072fc5839e312e35494d077848f3bbe1c3228a3d2bca2d3176bdcR17-R19): Added a nullable `Description` property with a maximum length of 500 characters to the `PgPost` class and updated explicit operators to include the `Description` field. [[1]](diffhunk://#diff-c2951412032072fc5839e312e35494d077848f3bbe1c3228a3d2bca2d3176bdcR17-R19) [[2]](diffhunk://#diff-c2951412032072fc5839e312e35494d077848f3bbe1c3228a3d2bca2d3176bdcR33) [[3]](diffhunk://#diff-c2951412032072fc5839e312e35494d077848f3bbe1c3228a3d2bca2d3176bdcR47)

### Database Migrations:

* [`SharpSite.Data.Postgres/Migrations/20241029161246_Add description to post.Designer.cs`](diffhunk://#diff-e6c2ed3ce0e47d7f54c69735f00f581823fbc2afcf11bd19f52ccde307e20492R1-R57): Generated migration designer file to add the `Description` column to the `Posts` table.
* [`SharpSite.Data.Postgres/Migrations/20241029161246_Add description to post.cs`](diffhunk://#diff-d0593d632fad4eba99b913ae7b0d84cbb581a33998104c6f93aeddbcc3ac3070R1-R29): Created migration file to add and remove the `Description` column in the `Posts` table.
* [`SharpSite.Data.Postgres/Migrations/PgContextModelSnapshot.cs`](diffhunk://#diff-d72b9660b0c45f93add903715b8c760ce3b0642e69c3c16cdb9d70b09176a4f2R35-R38): Updated the model snapshot to include the `Description` column.

### Front-End Updates:

* [`SharpSite.Web/Components/Admin/EditPost.razor`](diffhunk://#diff-9366f832f460fddb2b63e1239fa8e3b2ffd4aa40046b45d34c86d8ae56d53245R34-R39): Added a textarea input for the `Description` field in the post editing form.
* [`SharpSite.Web/Components/PostView.razor`](diffhunk://#diff-0baaedb0eb7f3a409e98f8111309db1a4b31aff76147f98d06bded8aea11f462R4): Displayed the `Description` field in the post view component.