### PR TITLE
Added RSS feed and initial cache flushing

### DIFF
--- a/SharpSite.Web/Components/Admin/EditPost.razor
+++ b/SharpSite.Web/Components/Admin/EditPost.razor
@@ -1,4 +1,5 @@
 @page "/admin/post/{urldate:int?}/{slug?}"
+@inject IOutputCacheStore OutputCacheStore
 @inject IPostRepository PostService
 @inject NavigationManager NavManager
 @rendermode InteractiveServer
@@ -75,12 +76,24 @@
 					Post.Slug = Post.GetSlug(Post.Title);
 					Console.WriteLine(Post.Slug);
 					await PostService.AddPost(Post);
+
+					// flush the outputcache for the sitemap and rss
+					await FlushCache();
+
 					NavManager.NavigateTo("/");
 				}
 				else
 				{
 					await PostService.UpdatePost(Post);
+					await FlushCache();
 					NavManager.NavigateTo("/");
 				}
 		}
+
+		private async Task FlushCache()
+		{
+				await OutputCacheStore.EvictByTagAsync("sitemap", CancellationToken.None);
+				await OutputCacheStore.EvictByTagAsync("rss", CancellationToken.None);
+		}
+
 }

--- a/SharpSite.Web/Components/App.razor
+++ b/SharpSite.Web/Components/App.razor
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="SharpSite.Web.styles.css" />
     <link rel="icon" type="image/png" href="favicon.png" />
     <link rel="sitemap" type="application/xml" title="Sitemap" href="/sitemap.xml" />
+		<link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml" />
 		<link href="/_content/PSC.Blazor.Components.MarkdownEditor/css/markdowneditor.css" rel="stylesheet" />
 		<link href="/_content/PSC.Blazor.Components.MarkdownEditor/css/easymde.min.css" rel="stylesheet" />
 

--- a/SharpSite.Web/Program.cs
+++ b/SharpSite.Web/Program.cs
@@ -37,6 +37,7 @@ app.MapRazorComponents<App>()
 
 app.MapSiteMap();
 app.MapRobotsTxt();
+app.MapRssFeed();
 app.MapDefaultEndpoints();
 
 app.Run();

--- a/SharpSite.Web/Rss.cs
+++ b/SharpSite.Web/Rss.cs
@@ -1,0 +1,65 @@
+using System.Net;
+using System.Security;
+using System.Text;
+using SharpSite.Abstractions;
+
+namespace SharpSite.Web;
+
+public static class Program_Rss
+{
+
+	public static WebApplication? MapRssFeed(this WebApplication? app)
+	{
+
+		if (app == null)
+		{
+			return null;
+		}
+
+		app.MapGet("/rss.xml", async (HttpContext context, IPostRepository postRepository) =>
+		{
+
+			var sb = new StringBuilder();
+			sb.AppendLine("<?xml version=\"1.0\" encoding=\"utf-8\"?>");
+			sb.AppendLine("<rss version=\"2.0\">");
+			sb.AppendLine("<channel>");
+			sb.AppendLine("<title>SharpSite</title>");
+			
+			// generate the feed link from the current request using the scheme and host name
+			sb.AppendLine($"<link>{context.Request.Scheme}://{context.Request.Host}</link>");
+
+			var posts = await postRepository.GetPosts();
+
+			foreach (var post in posts)
+			{
+
+				// generate the post link from the current request using the scheme and host name
+				var postLink = $"{context.Request.Scheme}://{context.Request.Host}{post.ToUrl()}";
+				// add the post to the stringbuilder xml document
+				sb.AppendLine("<item>");
+				sb.AppendLine($"<title>{SecurityElement.Escape(post.Title)}</title>");
+				sb.AppendLine($"<link>{postLink}</link>");
+				sb.AppendLine($"<description>{SecurityElement.Escape(post.Description)}</description>");
+				sb.AppendLine($"<pubDate>{post.PublishedDate.ToString("R")}</pubDate>");
+				sb.AppendLine("</item>");
+
+			}
+
+			sb.AppendLine("</channel>");
+			sb.AppendLine("</rss>");
+
+			context.Response.StatusCode = (int)HttpStatusCode.OK;
+			context.Response.ContentType = "application/rss+xml";
+			await context.Response.WriteAsync(sb.ToString());
+
+			}).CacheOutput(policy =>
+			{
+				policy.Tag("rss");
+				policy.Expire(TimeSpan.FromMinutes(30));
+			});
+
+		return app;
+
+	}
+
+}

--- a/SharpSite.Web/Sitemap.cs
+++ b/SharpSite.Web/Sitemap.cs
@@ -44,6 +44,11 @@ public static class ProgramExtensions_Sitemap
 
 			context.Response.ContentType = "application/xml";
 			await context.Response.WriteAsync(sb.ToString());
+		})
+		.CacheOutput(policy =>
+		{
+			policy.Tag("sitemap");
+			policy.Expire(TimeSpan.FromMinutes(30));
 		});
 		return app;
 


### PR DESCRIPTION
fixes #15 

This pull request introduces caching for the sitemap and RSS feed, along with some additional improvements to the RSS feed functionality. The most important changes include injecting the `IOutputCacheStore` service, adding cache flushing after post operations, mapping the RSS feed endpoint, and implementing the RSS feed generation.

Caching and Cache Flushing:

* [`SharpSite.Web/Components/Admin/EditPost.razor`](diffhunk://#diff-9366f832f460fddb2b63e1239fa8e3b2ffd4aa40046b45d34c86d8ae56d53245R2): Injected `IOutputCacheStore` and added the `FlushCache` method to clear the sitemap and RSS feed caches after adding or updating a post. [[1]](diffhunk://#diff-9366f832f460fddb2b63e1239fa8e3b2ffd4aa40046b45d34c86d8ae56d53245R2) [[2]](diffhunk://#diff-9366f832f460fddb2b63e1239fa8e3b2ffd4aa40046b45d34c86d8ae56d53245R79-R98)

RSS Feed Implementation:

* [`SharpSite.Web/Program.cs`](diffhunk://#diff-863bac57096eef5fcd79d5cabe53916404bf7e58da85ff3c542d8a4895dcbbc3R40): Added the `MapRssFeed` method to the application pipeline.
* [`SharpSite.Web/Rss.cs`](diffhunk://#diff-a0def0e57232bd3633903b8b39c9e230b1d16290c524ff54390f26c6987a3181R1-R65): Implemented the `MapRssFeed` extension method to generate and serve the RSS feed.

Sitemap Caching:

* [`SharpSite.Web/Sitemap.cs`](diffhunk://#diff-a7a0b8826bcbfc89cd425475afabdba5288e6709e03f8b5382bb5e1779bb4306R47-R51): Added caching to the sitemap endpoint with a 30-minute expiration policy.