### PR TITLE
Fix LoadPluginsAtStartup on fresh install

### DIFF
--- a/SharpSite.Web/PluginManager.cs
+++ b/SharpSite.Web/PluginManager.cs
@@ -127,7 +127,8 @@ public class PluginManager(ApplicationState AppState, ILogger<PluginManager> log
 
 	public static Task<ApplicationState> LoadPluginsAtStartup(ApplicationState state)
 	{
-		// Add your logic to load plugins at startup here
+		if (!Directory.Exists("plugins")) return Task.FromResult(state);
+
 		foreach (var pluginFolder in Directory.GetDirectories("plugins"))
 		{
 

--- a/SharpSite.Web/PluginManager.cs
+++ b/SharpSite.Web/PluginManager.cs
@@ -127,7 +127,13 @@ public class PluginManager(ApplicationState AppState, ILogger<PluginManager> log
 
 	public static Task<ApplicationState> LoadPluginsAtStartup(ApplicationState state)
 	{
-		if (!Directory.Exists("plugins")) return Task.FromResult(state);
+		if (!Directory.Exists("plugins"))
+		{
+			// create the plugins folder if it doesn't exist
+			Directory.CreateDirectory( "plugins");
+			Directory.CreateDirectory( "plugins/_wwwroot");
+			return Task.FromResult(state);
+		}
 
 		foreach (var pluginFolder in Directory.GetDirectories("plugins"))
 		{

--- a/SharpSite.Web/Program.cs
+++ b/SharpSite.Web/Program.cs
@@ -60,11 +60,6 @@ app.UseStaticFiles(new StaticFileOptions
 	FileProvider = new PhysicalFileProvider(Path.Combine(app.Environment.ContentRootPath, "wwwroot")),
 	RequestPath = ""
 });
-
-// create the plugins folder if it doesn't exist
-Directory.CreateDirectory(Path.Combine(app.Environment.ContentRootPath, "plugins"));
-Directory.CreateDirectory(Path.Combine(app.Environment.ContentRootPath, "plugins/_wwwroot"));
-
 app.UseStaticFiles(new StaticFileOptions
 {
 	FileProvider = new PhysicalFileProvider(Path.Combine(app.Environment.ContentRootPath, "plugins/_wwwroot")),


### PR DESCRIPTION
On a fresh install you will not have the plugins folder so exit out early.