### PR TITLE
Revert _wwwroot folder creation location

### DIFF
--- a/SharpSite.Web/PluginManager.cs
+++ b/SharpSite.Web/PluginManager.cs
@@ -131,7 +131,6 @@ public class PluginManager(ApplicationState AppState, ILogger<PluginManager> log
 		{
 			// create the plugins folder if it doesn't exist
 			Directory.CreateDirectory( "plugins");
-			Directory.CreateDirectory( "plugins/_wwwroot");
 			return Task.FromResult(state);
 		}
 

--- a/SharpSite.Web/Program.cs
+++ b/SharpSite.Web/Program.cs
@@ -54,7 +54,7 @@ if (!app.Environment.IsDevelopment())
 
 app.UseHttpsRedirection();
 
-
+Directory.CreateDirectory(Path.Combine(app.Environment.ContentRootPath, "plugins/_wwwroot"));
 var pluginRoot = new PhysicalFileProvider(Path.Combine(app.Environment.ContentRootPath, @"plugins/_wwwroot"));
 var compositeFileProvider = new CompositeFileProvider(app.Environment.WebRootFileProvider, pluginRoot);
 app.UseStaticFiles(new StaticFileOptions()


### PR DESCRIPTION
Not sure why I moved it in the other PR.

If you have plugins folder but no _wwwroot folder in it, `new PhysicalFileProvider(...)` fails.