### PR TITLE
Add plugins as cards on PluginList

### DIFF
--- a/SharpSite.Web/Components/Admin/PluginCard.razor
+++ b/SharpSite.Web/Components/Admin/PluginCard.razor
@@ -1,0 +1,19 @@
+﻿<div class="card plugin-card">
+	<div class="card-header d-flex align-items-baseline gap-1">
+		<h5 class="card-title mb-0">@Plugin.DisplayName</h5>
+		<span>&mdash;</span>
+		<small class="text-muted">@Plugin.Version</small>
+	</div>
+	<img src="@Plugin.Icon" alt="Plugin icon" class="card-img-top"/>
+	<div class="card-body">
+		<p class="card-text">@Plugin.Description</p>
+	</div>
+	<div class="card-footer d-flex justify-content-between">
+		<button type="button" class="btn btn-info">Update</button>
+		<button type="button" class="btn btn-danger">Remove</button>
+	</div>
+</div>
+
+@code {
+	[Parameter, EditorRequired] public required PluginManifest Plugin { get; set; }
+}

--- a/SharpSite.Web/Components/Admin/PluginCard.razor.css
+++ b/SharpSite.Web/Components/Admin/PluginCard.razor.css
@@ -1,0 +1,8 @@
+﻿.plugin-card {
+    width: 14rem;
+}
+
+.plugin-icon {
+    aspect-ratio: 1;
+    object-fit: cover;
+}

--- a/SharpSite.Web/Components/Admin/PluginList.razor
+++ b/SharpSite.Web/Components/Admin/PluginList.razor
@@ -18,12 +18,12 @@
 }
 else
 {
-	<ul>
+	<div class="d-flex flex-wrap gap-3">
 		@foreach (var plugin in AppState.Plugins)
 		{
-			<li>@plugin.Value.DisplayName - @plugin.Value.Version</li>
+			<PluginCard Plugin="plugin.Value" />
 		}
-	</ul>
+	</div>
 }
 
 @code {

--- a/SharpSite.Web/SharpSite.Web.csproj
+++ b/SharpSite.Web/SharpSite.Web.csproj
@@ -35,5 +35,13 @@
     <EditorConfigFiles Remove="D:\SharpSite\SharpSite.Web\.editorconfig" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Remove="Components\Admin\PluginCard.razor.css" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="Components\Admin\PluginCard.razor.css" />
+  </ItemGroup>
+
 
 </Project>


### PR DESCRIPTION
Plugins as Bootstrap cards on Plugin list page.

![image](https://github.com/user-attachments/assets/32e11d14-0fec-4a70-ba98-f9a1a42c250f)
(buttons are just placeholders)

Resolve FritzAndFriends/SharpSite#112