### PR TITLE
Add Supported Languages and Robots.txt Admin Settings

### DIFF
--- a/SharpSite.Web/ApplicatonState.cs
+++ b/SharpSite.Web/ApplicatonState.cs
@@ -10,7 +10,11 @@ public class ApplicationState
 {
 	public record CurrentThemeRecord(string IdVersion);
 
+	public record LocalizationRecord(string? DefaultCulture, string[]? SupportedCultures);
+
 	public CurrentThemeRecord? CurrentTheme { get; set; }
+
+	public LocalizationRecord? Localization { get; set; }
 
 	/// <summary>
 	/// Maximum file upload size in megabytes.
@@ -76,6 +80,7 @@ public class ApplicationState
 			{
 				CurrentTheme = state.CurrentTheme;
 				MaximumUploadSizeMB = state.MaximumUploadSizeMB;
+				Localization = state.Localization;
 			}
 		}
 	}

--- a/SharpSite.Web/ApplicatonState.cs
+++ b/SharpSite.Web/ApplicatonState.cs
@@ -16,6 +16,8 @@ public class ApplicationState
 
 	public LocalizationRecord? Localization { get; set; }
 
+	public string? RobotsTxtCustomContent { get; set; }
+
 	/// <summary>
 	/// Maximum file upload size in megabytes.
 	/// </summary>
@@ -81,6 +83,7 @@ public class ApplicationState
 				CurrentTheme = state.CurrentTheme;
 				MaximumUploadSizeMB = state.MaximumUploadSizeMB;
 				Localization = state.Localization;
+				RobotsTxtCustomContent = state.RobotsTxtCustomContent;
 			}
 		}
 	}

--- a/SharpSite.Web/Components/Admin/AdminSiteSettings.razor
+++ b/SharpSite.Web/Components/Admin/AdminSiteSettings.razor
@@ -28,7 +28,7 @@
 			<button class="btn btn-primary" @onclick="ChangeMaxSize">@Localizer[SharedResource.sharpsite_save]</button>
 		</div>
 
-		<div class="col-lg-8">
+		<div class="col-lg-8 mb-2">
 			<h4>@Localizer[SharedResource.sharpsite_lang_heading]</h4>
 			<div class="mb-2">
 				<label for="default-culture-select" class="form-label">
@@ -59,6 +59,21 @@
 			</div>
 			<button class="btn btn-primary mt-2" @onclick="ChangeCultureSettings">@Localizer[SharedResource.sharpsite_save]</button>
 		</div>
+
+		<div class="col-lg-8 mb-4">
+			<h4>Robots.txt</h4>
+			<p>
+				@Localizer[SharedResource.sharpsite_robotstxt_help_text]
+				<pre><code>User-agent: *</code>&#10;<code>Disallow: /Admin/</code>&#10;<code>Sitemap: &lt;your-domain&gt;/sitemap.xml</code></pre>
+			</p>
+			<label for="robots-txt-content-textarea" class="form-label">@Localizer[SharedResource.sharpsite_robotstxt_label]</label>
+			<InputTextArea id="robots-txt-content-textarea"
+			class="form-control"
+			rows="3"
+			@bind-Value="Model.RobotsTxtCustomContent"
+			placeholder="User-agent: Example-Bot&#10;Disallow: /&#10;Allow: /for-example-bot"></InputTextArea>
+			<button class="btn btn-primary mt-2" @onclick="ChangeRobotsTxtContent">@Localizer[SharedResource.sharpsite_save]</button>
+		</div>
 	</EditForm>
 
 </AuthorizeView>
@@ -73,6 +88,7 @@
 		Model.MaxSizeMB = ApplicationState.MaximumUploadSizeMB;
 		Model.DefaultCulture = ApplicationState.Localization?.DefaultCulture ?? "en";
 		Model.SupportedCultures = ApplicationState.Localization?.SupportedCultures;
+		Model.RobotsTxtCustomContent = ApplicationState.RobotsTxtCustomContent;
 
 		base.OnInitialized();
 
@@ -117,6 +133,14 @@
 
 	}
 
+	private async Task ChangeRobotsTxtContent(MouseEventArgs e)
+	{
+
+		ApplicationState.RobotsTxtCustomContent = string.IsNullOrEmpty(Model.RobotsTxtCustomContent) ? null : Model.RobotsTxtCustomContent;
+		await ApplicationState.Save();
+
+	}
+
 	private string GetLocalizerKey(string culture) =>
 		SharedResource.ResourceManager.GetString($"sharpsite_lang_{culture}") ??
 		throw new ArgumentException($"The culture '{culture}' is not implemented.", nameof(culture));
@@ -129,6 +153,8 @@
 		public string[]? SupportedCultures { get; set; }
 
 		public string? DefaultCulture { get; set; }
+
+		public string? RobotsTxtCustomContent { get; set; }
 	}
 
 }

--- a/SharpSite.Web/Components/Admin/AdminSiteSettings.razor
+++ b/SharpSite.Web/Components/Admin/AdminSiteSettings.razor
@@ -1,27 +1,64 @@
 @using Microsoft.AspNetCore.SignalR
 @using Microsoft.Extensions.Options
 @using System.ComponentModel.DataAnnotations
+@using Locales = SharpSite.Web.Locales
 @inject IOptions<HubOptions> HubOptions
+@inject IOptions<RequestLocalizationOptions> LocalizationOptions
 @inject ApplicationState ApplicationState
+@inject NavigationManager Navigation
 @rendermode @(new InteractiveServerRenderMode(true))
 
 <AuthorizeView Roles="@Constants.Roles.Admin" Context="AuthorizeContext">
 	<h3>
-		@Localizer[SharedResource.sharpsite_sitesettings]</h3>
+		@Localizer[SharedResource.sharpsite_sitesettings]
+	</h3>
 
 	<EditForm Model="Model">
 		<DataAnnotationsValidator />
 
-		<label for="maxsize">
-			@Localizer[SharedResource.sharpsite_maxupload_label]</label>
+		<div class="mb-2">
+			<label for="maxsize">
+				@Localizer[SharedResource.sharpsite_maxupload_label]
+			</label>
 
-		<InputNumber id="maxsize" @bind-Value="Model.MaxSizeMB" /> MB
-		<p>
-			<ValidationMessage For="@(() => Model.MaxSizeMB)" />
-		</p>
-		<button class="btn btn-primary" @onclick="ChangeMaxSize">@Localizer[SharedResource.sharpsite_save]</button>
+			<InputNumber id="maxsize" @bind-Value="Model.MaxSizeMB" /> MB
+			<p>
+				<ValidationMessage For="@(() => Model.MaxSizeMB)" />
+			</p>
+			<button class="btn btn-primary" @onclick="ChangeMaxSize">@Localizer[SharedResource.sharpsite_save]</button>
+		</div>
 
-
+		<div class="col-lg-8">
+			<h4>@Localizer[SharedResource.sharpsite_lang_heading]</h4>
+			<div class="mb-2">
+				<label for="default-culture-select" class="form-label">
+					@Localizer[SharedResource.sharpsite_lang_default_label]
+				</label>
+				<InputSelect id="default-culture-select" @bind-Value="Model.DefaultCulture" class="form-select">
+					@foreach (var culture in Locales.Configuration.SupportedCultures.OrderBy(c => c))
+					{
+						<option value="@culture" disabled="@(Model.SupportedCultures?.Length == 0 ? false : !Model.SupportedCultures?.Contains(culture))">
+							@Localizer[GetLocalizerKey(culture)] &#40;@Locales.Configuration.LocalizedCultureNames[@culture]&#41;
+						</option>
+					}
+				</InputSelect>
+			</div>
+			<div>
+				<label for="supported-cultures-select" class="form-label">
+					@Localizer[SharedResource.sharpsite_lang_supported_label]
+				</label>
+				<select id="supported-cultures-select" multiple @onchange="OnCultureChanged" class="form-select">
+					@foreach (var culture in Locales.Configuration.SupportedCultures.OrderBy(c => c))
+					{
+						<option value="@culture" selected="@(Model.SupportedCultures?.Contains(culture))">
+							@Localizer[GetLocalizerKey(culture)] &#40;@Locales.Configuration.LocalizedCultureNames[@culture]&#41;
+						</option>
+					}
+				</select>
+				<small class="text-muted">@Localizer[SharedResource.sharpsite_lang_supported_help_text]</small>
+			</div>
+			<button class="btn btn-primary mt-2" @onclick="ChangeCultureSettings">@Localizer[SharedResource.sharpsite_save]</button>
+		</div>
 	</EditForm>
 
 </AuthorizeView>
@@ -32,8 +69,13 @@
 
 	protected override void OnInitialized()
 	{
+
 		Model.MaxSizeMB = ApplicationState.MaximumUploadSizeMB;
+		Model.DefaultCulture = ApplicationState.Localization?.DefaultCulture ?? "en";
+		Model.SupportedCultures = ApplicationState.Localization?.SupportedCultures;
+
 		base.OnInitialized();
+
 	}
 
 	private async Task ChangeMaxSize(MouseEventArgs e)
@@ -47,11 +89,46 @@
 
 	}
 
+	private void OnCultureChanged(ChangeEventArgs e)
+	{
+
+		string[]? selectedCultures = e.Value as string[];
+		Model.SupportedCultures = selectedCultures?.Length > 0 ? selectedCultures : null;
+		if (Model.SupportedCultures?.Length > 0 && !Model.SupportedCultures.Contains(Model.DefaultCulture))
+		{
+			Model.DefaultCulture = Model.SupportedCultures.First();
+		}
+
+	}
+
+	private async Task ChangeCultureSettings(MouseEventArgs e)
+	{
+
+		ApplicationState.Localization = new(Model.DefaultCulture, Model.SupportedCultures);
+		if (!string.IsNullOrEmpty(Model.DefaultCulture))
+		{
+			LocalizationOptions.Value.SetDefaultCulture(Model.DefaultCulture);
+		}
+		LocalizationOptions.Value.SupportedCultures = [];
+		LocalizationOptions.Value.AddSupportedCultures(ApplicationState.Localization.SupportedCultures ?? Locales.Configuration.SupportedCultures);
+
+		await ApplicationState.Save();
+		Navigation.Refresh();
+
+	}
+
+	private string GetLocalizerKey(string culture) =>
+		SharedResource.ResourceManager.GetString($"sharpsite_lang_{culture}") ??
+		throw new ArgumentException($"The culture '{culture}' is not implemented.", nameof(culture));
+
 	public class ViewModel
 	{
 		[Range(1, 100), Required]
 		public long MaxSizeMB { get; set; }
-	}
 
+		public string[]? SupportedCultures { get; set; }
+
+		public string? DefaultCulture { get; set; }
+	}
 
 }

--- a/SharpSite.Web/Components/LanguagePicker.razor
+++ b/SharpSite.Web/Components/LanguagePicker.razor
@@ -3,28 +3,28 @@
 @inject IOptions<RequestLocalizationOptions> LocalizationOptions
 @inject NavigationManager Navigation
 
-<div class="mt-3 mb-3 mx-5">
-    @if (LocalizationOptions.Value.SupportedCultures != null)
-    {
-        @foreach (var culture in LocalizationOptions.Value.SupportedCultures.OrderBy(c => c.IetfLanguageTag))
-        {
-            <a onclick="location.href = '@SetCulture(culture.Name)'" 
-							role="button"
-							title="@culture.NativeName"
-							class="text-decoration-none" href="#">
-                <span class="badge rounded-pill mx-1 @(culture.ToString() == CultureInfo.CurrentCulture.ToString()?"bg-primary":"bg-primary-dark")">@culture</span>
-            </a>
-        }
-    }
-</div>
+@if (LocalizationOptions.Value.SupportedCultures is not null && LocalizationOptions.Value.SupportedCultures.Count > 1)
+{
+	<div class="mt-3 mb-3 mx-5">
+		@foreach (var culture in LocalizationOptions.Value.SupportedCultures.OrderBy(c => c.IetfLanguageTag))
+		{
+			<a onclick="location.href = '@SetCulture(culture.Name)'"
+			   role="button"
+			   title="@culture.NativeName"
+			   class="text-decoration-none" href="#">
+				<span class="badge rounded-pill mx-1 @(culture.ToString() == CultureInfo.CurrentCulture.ToString() ? "bg-primary" : "bg-primary-dark")">@culture</span>
+			</a>
+		}
+	</div>
+}
 
 @code
 {
-    private string SetCulture(string culture)
-    {
-        const string cultureParamName = "culture";
+	private string SetCulture(string culture)
+	{
+		const string cultureParamName = "culture";
 
-        var url = Navigation.GetUriWithQueryParameter(cultureParamName, culture);
-        return url;
-    }
+		var url = Navigation.GetUriWithQueryParameter(cultureParamName, culture);
+		return url;
+	}
 }

--- a/SharpSite.Web/Locales/Configuration.cs
+++ b/SharpSite.Web/Locales/Configuration.cs
@@ -1,8 +1,10 @@
+﻿using System.Collections.Frozen;
+
 namespace SharpSite.Web.Locales;
 public static class Configuration
 {
 
-	public readonly static string[] SupportedCultures = {
+	public readonly static string[] SupportedCultures = [
 		"bg",
 		"en",
 		"es",
@@ -15,7 +17,22 @@ public static class Configuration
 		"sw",
 		"de",
 		"ca",
-	};
+	];
+	public readonly static FrozenDictionary<string, string> LocalizedCultureNames = new Dictionary<string, string>()
+	{
+		// NOTE: These should be checked by for correctness.
+		{ "bg", "Български" },
+		{ "ca", "Català" },
+		{ "de", "Deutsch" },
+		{ "en", "English" },
+		{ "es", "Español" },
+		{ "fi", "Suomi" },
+		{ "fr", "Français" },
+		{ "it", "Italiano" },
+		{ "nl", "Nederlands" },
+		{ "pt", "Português" },
+		{ "sw", "Kiswahili" },
+	}.ToFrozenDictionary();
 
 	/// <summary>
 	/// add the custom localization features for the application framework
@@ -24,12 +41,14 @@ public static class Configuration
 	public static void ConfigureRequestLocalization(this WebApplicationBuilder builder)
 	{
 
+		var appState = builder.Services.BuildServiceProvider().GetRequiredService<ApplicationState>();
+		var cultures = appState.Localization?.SupportedCultures ?? SupportedCultures;
+		var defaultCulture = appState.Localization?.DefaultCulture ?? "en";
 		builder.Services.Configure<RequestLocalizationOptions>(options =>
 		{
-
-			options.SetDefaultCulture("en")
-									.AddSupportedCultures(SupportedCultures)
-									.AddSupportedUICultures(SupportedCultures);
+			options.SetDefaultCulture(defaultCulture)
+									.AddSupportedCultures(cultures)
+									.AddSupportedUICultures(cultures);
 		});
 
 		builder.Services.AddLocalization(options =>

--- a/SharpSite.Web/Locales/SharedResource.Designer.cs
+++ b/SharpSite.Web/Locales/SharedResource.Designer.cs
@@ -259,6 +259,141 @@ namespace SharpSite.Web.Locales {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Bulgarian.
+        /// </summary>
+        internal static string sharpsite_lang_bg {
+            get {
+                return ResourceManager.GetString("sharpsite_lang_bg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Catalan.
+        /// </summary>
+        internal static string sharpsite_lang_ca {
+            get {
+                return ResourceManager.GetString("sharpsite_lang_ca", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to German.
+        /// </summary>
+        internal static string sharpsite_lang_de {
+            get {
+                return ResourceManager.GetString("sharpsite_lang_de", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Select the default language.
+        /// </summary>
+        internal static string sharpsite_lang_default_label {
+            get {
+                return ResourceManager.GetString("sharpsite_lang_default_label", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to English.
+        /// </summary>
+        internal static string sharpsite_lang_en {
+            get {
+                return ResourceManager.GetString("sharpsite_lang_en", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Spanish.
+        /// </summary>
+        internal static string sharpsite_lang_es {
+            get {
+                return ResourceManager.GetString("sharpsite_lang_es", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Finnish.
+        /// </summary>
+        internal static string sharpsite_lang_fi {
+            get {
+                return ResourceManager.GetString("sharpsite_lang_fi", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to French.
+        /// </summary>
+        internal static string sharpsite_lang_fr {
+            get {
+                return ResourceManager.GetString("sharpsite_lang_fr", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Language Settings.
+        /// </summary>
+        internal static string sharpsite_lang_heading {
+            get {
+                return ResourceManager.GetString("sharpsite_lang_heading", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Italian.
+        /// </summary>
+        internal static string sharpsite_lang_it {
+            get {
+                return ResourceManager.GetString("sharpsite_lang_it", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Dutch.
+        /// </summary>
+        internal static string sharpsite_lang_nl {
+            get {
+                return ResourceManager.GetString("sharpsite_lang_nl", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Portuguese.
+        /// </summary>
+        internal static string sharpsite_lang_pt {
+            get {
+                return ResourceManager.GetString("sharpsite_lang_pt", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to If no options are selected, it is equivalent to selecting all options..
+        /// </summary>
+        internal static string sharpsite_lang_supported_help_text {
+            get {
+                return ResourceManager.GetString("sharpsite_lang_supported_help_text", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Select the supported languages.
+        /// </summary>
+        internal static string sharpsite_lang_supported_label {
+            get {
+                return ResourceManager.GetString("sharpsite_lang_supported_label", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Kiswahili.
+        /// </summary>
+        internal static string sharpsite_lang_sw {
+            get {
+                return ResourceManager.GetString("sharpsite_lang_sw", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Loading....
         /// </summary>
         internal static string sharpsite_loading {

--- a/SharpSite.Web/Locales/SharedResource.Designer.cs
+++ b/SharpSite.Web/Locales/SharedResource.Designer.cs
@@ -646,6 +646,24 @@ namespace SharpSite.Web.Locales {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The file aleady contains the following:.
+        /// </summary>
+        internal static string sharpsite_robotstxt_help_text {
+            get {
+                return ResourceManager.GetString("sharpsite_robotstxt_help_text", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Robots.txt Content.
+        /// </summary>
+        internal static string sharpsite_robotstxt_label {
+            get {
+                return ResourceManager.GetString("sharpsite_robotstxt_label", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Save.
         /// </summary>
         internal static string sharpsite_save {

--- a/SharpSite.Web/Locales/SharedResource.en.resx
+++ b/SharpSite.Web/Locales/SharedResource.en.resx
@@ -346,4 +346,10 @@
   <data name="sharpsite_lang_supported_help_text" xml:space="preserve">
     <value>If no options are selected, it is equivalent to selecting all options.</value>
   </data>
+  <data name="sharpsite_robotstxt_label" xml:space="preserve">
+    <value>Add to Robots.txt file</value>
+  </data>
+  <data name="sharpsite_robotstxt_help_text" xml:space="preserve">
+    <value>The file aleady contains the following:</value>
+  </data>
 </root>

--- a/SharpSite.Web/Locales/SharedResource.en.resx
+++ b/SharpSite.Web/Locales/SharedResource.en.resx
@@ -253,6 +253,9 @@
   <data name="sharpsite_login" xml:space="preserve">
     <value>Login</value>
   </data>
+  <data name="sharpsite_useradmin" xml:space="preserve">
+    <value>User Admin</value>
+  </data>
   <data name="sharpsite_generaladmin" xml:space="preserve">
     <value>General</value>
   </data>
@@ -297,5 +300,50 @@
   </data>
   <data name="sharpsite_site_appearance_admin" xml:space="preserve">
     <value>Site appearance</value>
+  </data>
+  <data name="sharpsite_lang_supported_label" xml:space="preserve">
+    <value>Select the supported languages</value>
+  </data>
+  <data name="sharpsite_lang_default_label" xml:space="preserve">
+    <value>Select the default language</value>
+  </data>
+  <data name="sharpsite_lang_en" xml:space="preserve">
+    <value>English</value>
+  </data>
+  <data name="sharpsite_lang_bg" xml:space="preserve">
+    <value>Bulgarian</value>
+  </data>
+  <data name="sharpsite_lang_ca" xml:space="preserve">
+    <value>Catalan</value>
+  </data>
+  <data name="sharpsite_lang_es" xml:space="preserve">
+    <value>Spanish</value>
+  </data>
+  <data name="sharpsite_lang_fi" xml:space="preserve">
+    <value>Finnish</value>
+  </data>
+  <data name="sharpsite_lang_fr" xml:space="preserve">
+    <value>French</value>
+  </data>
+  <data name="sharpsite_lang_it" xml:space="preserve">
+    <value>Italian</value>
+  </data>
+  <data name="sharpsite_lang_nl" xml:space="preserve">
+    <value>Dutch</value>
+  </data>
+  <data name="sharpsite_lang_de" xml:space="preserve">
+    <value>German</value>
+  </data>
+  <data name="sharpsite_lang_sw" xml:space="preserve">
+    <value>Kiswahili</value>
+  </data>
+  <data name="sharpsite_lang_pt" xml:space="preserve">
+    <value>Portuguese</value>
+  </data>
+  <data name="sharpsite_lang_heading" xml:space="preserve">
+    <value>Language Settings</value>
+  </data>
+  <data name="sharpsite_lang_supported_help_text" xml:space="preserve">
+    <value>If no options are selected, it is equivalent to selecting all options.</value>
   </data>
 </root>

--- a/SharpSite.Web/Locales/SharedResource.fi.resx
+++ b/SharpSite.Web/Locales/SharedResource.fi.resx
@@ -313,4 +313,10 @@
   <data name="sharpsite_lang_supported_help_text" xml:space="preserve">
     <value>Jos mitään vaihtoehtoa ei ole valittu, se vastaa kaikkien vaihtoehtojen valitsemista.</value>
   </data>
+  <data name="sharpsite_robotstxt_label" xml:space="preserve">
+    <value>Lisää Robots.txt tiedostoon</value>
+  </data>
+  <data name="sharpsite_robotstxt_help_text" xml:space="preserve">
+    <value>Tiedosto sisältää jo seuraavan:</value>
+  </data>
 </root>

--- a/SharpSite.Web/Locales/SharedResource.fi.resx
+++ b/SharpSite.Web/Locales/SharedResource.fi.resx
@@ -301,4 +301,16 @@
   <data name="sharpsite_site_appearance_admin" xml:space="preserve">
     <value>Sivun ulkonäkö</value>
   </data>
+  <data name="sharpsite_lang_supported_label" xml:space="preserve">
+    <value>Valitse tuetut kielet</value>
+  </data>
+  <data name="sharpsite_lang_default_label" xml:space="preserve">
+    <value>Valitse olutuskieli</value>
+  </data>
+  <data name="sharpsite_lang_heading" xml:space="preserve">
+    <value>Kieliasetukset</value>
+  </data>
+  <data name="sharpsite_lang_supported_help_text" xml:space="preserve">
+    <value>Jos mitään vaihtoehtoa ei ole valittu, se vastaa kaikkien vaihtoehtojen valitsemista.</value>
+  </data>
 </root>

--- a/SharpSite.Web/Locales/SharedResource.resx
+++ b/SharpSite.Web/Locales/SharedResource.resx
@@ -311,4 +311,53 @@
   <data name="sharpsite_site_appearance_admin" xml:space="preserve">
     <value>Site appearance</value>
   </data>
+  <data name="sharpsite_lang_supported_label" xml:space="preserve">
+    <value>Select the supported languages</value>
+    <comment>Label for admin setting for supported localized languages for SharpSite</comment>
+  </data>
+  <data name="sharpsite_lang_default_label" xml:space="preserve">
+    <value>Select the default language</value>
+    <comment>Label for admin setting for the default localized language</comment>
+  </data>
+  <data name="sharpsite_lang_en" xml:space="preserve">
+    <value>English</value>
+  </data>
+  <data name="sharpsite_lang_bg" xml:space="preserve">
+    <value>Bulgarian</value>
+  </data>
+  <data name="sharpsite_lang_ca" xml:space="preserve">
+    <value>Catalan</value>
+  </data>
+  <data name="sharpsite_lang_es" xml:space="preserve">
+    <value>Spanish</value>
+  </data>
+  <data name="sharpsite_lang_fi" xml:space="preserve">
+    <value>Finnish</value>
+  </data>
+  <data name="sharpsite_lang_fr" xml:space="preserve">
+    <value>French</value>
+  </data>
+  <data name="sharpsite_lang_it" xml:space="preserve">
+    <value>Italian</value>
+  </data>
+  <data name="sharpsite_lang_nl" xml:space="preserve">
+    <value>Dutch</value>
+  </data>
+  <data name="sharpsite_lang_de" xml:space="preserve">
+    <value>German</value>
+  </data>
+  <data name="sharpsite_lang_sw" xml:space="preserve">
+    <value>Kiswahili</value>
+  </data>
+  <data name="sharpsite_lang_pt" xml:space="preserve">
+    <value>Portuguese</value>
+  </data>
+  <data name="sharpsite_lang_heading" xml:space="preserve">
+    <value>Language Settings</value>
+    <comment>Heading for the language/culture settings</comment>
+  </data>
+  <data name="sharpsite_lang_supported_help_text" xml:space="preserve">
+    <value>If no options are selected, it is equivalent to selecting all options.</value>
+    <comment>Help text for supported languages admin setting</comment>
+  </data>
 </root>

--- a/SharpSite.Web/Locales/SharedResource.resx
+++ b/SharpSite.Web/Locales/SharedResource.resx
@@ -360,4 +360,12 @@
     <value>If no options are selected, it is equivalent to selecting all options.</value>
     <comment>Help text for supported languages admin setting</comment>
   </data>
+  <data name="sharpsite_robotstxt_label" xml:space="preserve">
+    <value>Robots.txt Content</value>
+    <comment>Label for robots.txt content admin setting</comment>
+  </data>
+  <data name="sharpsite_robotstxt_help_text" xml:space="preserve">
+    <value>The file aleady contains the following:</value>
+    <comment>Help text for robots.txt content admin setting</comment>
+  </data>
 </root>

--- a/SharpSite.Web/RobotsTxt.cs
+++ b/SharpSite.Web/RobotsTxt.cs
@@ -15,6 +15,12 @@ public static class Program_RobotsTxt
 			sb.AppendLine("User-agent: *");
 			sb.AppendLine("Disallow: /admin/");
 
+			var appState = app.Services.GetRequiredService<ApplicationState>();
+			if (!string.IsNullOrEmpty(appState.RobotsTxtCustomContent))
+			{
+				sb.AppendLine(appState.RobotsTxtCustomContent);
+			}
+
 			// add a line for the sitemap using the base URL from the context
 			sb.AppendLine($"Sitemap: {context.Request.Scheme}://{context.Request.Host}/sitemap.xml");
 

--- a/SharpSite.Web/RobotsTxt.cs
+++ b/SharpSite.Web/RobotsTxt.cs
@@ -7,7 +7,7 @@ public static class Program_RobotsTxt
 
 	public static WebApplication MapRobotsTxt(this WebApplication app)
 	{
-		app.MapGet("/robots.txt", async (HttpContext context) =>
+		app.MapGet("/robots.txt", async (HttpContext context, ApplicationState appState) =>
 		{
 			context.Response.ContentType = "text/plain";
 
@@ -15,7 +15,6 @@ public static class Program_RobotsTxt
 			sb.AppendLine("User-agent: *");
 			sb.AppendLine("Disallow: /admin/");
 
-			var appState = app.Services.GetRequiredService<ApplicationState>();
 			if (!string.IsNullOrEmpty(appState.RobotsTxtCustomContent))
 			{
 				sb.AppendLine(appState.RobotsTxtCustomContent);
@@ -31,9 +30,7 @@ public static class Program_RobotsTxt
 			policy.Expire(TimeSpan.FromDays(30));
 		});
 
-
 		return app;
-
 	}
 
 }


### PR DESCRIPTION
Fix FritzAndFriends/SharpSite#58

I also added a select for the default cultures since there might be users who don't want to support English
or that the default should be something else (e.g. I want to support Finnish, Swedish, and English but I want to default to Finnish).

I'm not entirely sure setting a new default culture takes effect immediately. It seems to work best if you also remove the old one from supported cultures and then add it back after. But this needs further investigation. 