### PR TITLE
Add language code to Post and Page models

### DIFF
--- a/SharpSite.Abstractions/Page.cs
+++ b/SharpSite.Abstractions/Page.cs
@@ -18,4 +18,7 @@ public class Page
 
 	public required DateTimeOffset LastUpdate { get; set; } = DateTimeOffset.Now;
 
+	[Required, MaxLength(11)]
+	public string LanguageCode { get; set; } = "en";
+
 }

--- a/SharpSite.Abstractions/Post.cs
+++ b/SharpSite.Abstractions/Post.cs
@@ -30,6 +30,9 @@ public class Post
 	[Required]
 	public DateTimeOffset LastUpdate { get; set; } = DateTimeOffset.Now;
 
+	[Required, MaxLength(11)]
+	public string LanguageCode { get; set; } = "en";
+
 	public static string GetSlug(string title)
 	{
 		var slug = title.ToLower().Replace(" ", "-");

--- a/SharpSite.Data.Postgres/Migrations/20250101182712_AddLanguageCodeToPostsAndPages.Designer.cs
+++ b/SharpSite.Data.Postgres/Migrations/20250101182712_AddLanguageCodeToPostsAndPages.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SharpSite.Data.Postgres;
@@ -11,9 +12,11 @@ using SharpSite.Data.Postgres;
 namespace SharpSite.Data.Postgres.Migrations
 {
     [DbContext(typeof(PgContext))]
-    partial class PgContextModelSnapshot : ModelSnapshot
+    [Migration("20250101182712_AddLanguageCodeToPostsAndPages")]
+    partial class AddLanguageCodeToPostsAndPages
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/SharpSite.Data.Postgres/Migrations/20250101182712_AddLanguageCodeToPostsAndPages.cs
+++ b/SharpSite.Data.Postgres/Migrations/20250101182712_AddLanguageCodeToPostsAndPages.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SharpSite.Data.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddLanguageCodeToPostsAndPages : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "LanguageCode",
+                table: "Posts",
+                type: "character varying(11)",
+                maxLength: 11,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "LanguageCode",
+                table: "Pages",
+                type: "character varying(11)",
+                maxLength: 11,
+                nullable: false,
+                defaultValue: "");
+
+            // Update existing rows with default value "en"
+            migrationBuilder.Sql("UPDATE \"Posts\" SET \"LanguageCode\" = 'en' WHERE \"LanguageCode\" = ''");
+            migrationBuilder.Sql("UPDATE \"Pages\" SET \"LanguageCode\" = 'en' WHERE \"LanguageCode\" = ''");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "LanguageCode",
+                table: "Posts");
+
+            migrationBuilder.DropColumn(
+                name: "LanguageCode",
+                table: "Pages");
+        }
+    }
+}

--- a/SharpSite.Data.Postgres/PgPage.cs
+++ b/SharpSite.Data.Postgres/PgPage.cs
@@ -19,6 +19,10 @@ public class PgPage
 
 	public DateTimeOffset LastUpdate { get; set; } = DateTimeOffset.Now;
 
+
+	[Required, MaxLength(11)]
+	public string LanguageCode { get; set; } = "en";
+
 	public static explicit operator PgPage(Page page)
 	{
 
@@ -28,7 +32,8 @@ public class PgPage
 			Title = page.Title,
 			Slug = page.Slug,
 			Content = page.Content,
-			LastUpdate = page.LastUpdate
+			LastUpdate = page.LastUpdate,
+			LanguageCode = page.LanguageCode
 		};
 
 	}
@@ -41,7 +46,8 @@ public class PgPage
 			Title = page.Title,
 			Slug = page.Slug,
 			Content = page.Content,
-			LastUpdate = page.LastUpdate
+			LastUpdate = page.LastUpdate,
+			LanguageCode = page.LanguageCode
 		};
 	}
 

--- a/SharpSite.Data.Postgres/PgPost.cs
+++ b/SharpSite.Data.Postgres/PgPost.cs
@@ -26,6 +26,9 @@ public class PgPost
 	[Required]
 	public required DateTimeOffset LastUpdate { get; set; } = DateTimeOffset.Now;
 
+	[Required, MaxLength(11)]
+	public string LanguageCode { get; set; } = "en";
+
 	public static explicit operator PgPost(SharpSite.Abstractions.Post post)
 	{
 
@@ -37,6 +40,7 @@ public class PgPost
 			Content = post.Content,
 			Published = post.PublishedDate,
 			LastUpdate = post.LastUpdate,
+			LanguageCode = post.LanguageCode,
 		};
 
 	}
@@ -52,6 +56,7 @@ public class PgPost
 			Content = post.Content,
 			PublishedDate = post.Published,
 			LastUpdate = post.LastUpdate,
+			LanguageCode = post.LanguageCode,
 		};
 
 	}

--- a/SharpSite.Web/Components/Admin/EditPage.razor
+++ b/SharpSite.Web/Components/Admin/EditPage.razor
@@ -9,17 +9,18 @@
 
 @if (Page != null)
 {
-	<div class="form-group">
-	<label for="title">@Localizer[SharedResource.sharpsite_editpost_title]</label>
-	<br/>
-	<input type="text" class="form-control" id="title" @bind="Page.Title" />
-</div>
-	<div class="form-group">
-	<label for="content">@Localizer[SharedResource.sharpsite_editpost_content]</label>
-	<br/>
-	<TextEditor @bind-Content="@Page.Content" />
-</div>
-	<button class="btn btn-primary my-2" @onclick="SavePage">@Localizer[SharedResource.sharpsite_save]</button>
+	<div class="mb-2">
+		<label for="title">@Localizer[SharedResource.sharpsite_editpost_title]</label>
+		<br />
+		<input type="text" class="form-control" id="title" @bind="Page.Title" />
+	</div>
+	<div class="mb-2">
+		<label for="content">@Localizer[SharedResource.sharpsite_editpost_content]</label>
+		<br />
+		<TextEditor @bind-Content="@Page.Content" />
+	</div>
+	<LanguageSelect @bind-Language="@Page.LanguageCode" />
+	<button class="btn btn-primary mb-2" @onclick="SavePage">@Localizer[SharedResource.sharpsite_save]</button>
 }
 
 @code {
@@ -35,7 +36,7 @@
 		if (Id != 0)
 		{
 			Page = await PageRepository.GetPage(Id);
-			ThisPageTitle = Localizer["sharpsite_editpage"];
+			ThisPageTitle = Localizer[SharedResource.sharpsite_editpage];
 		}
 		else
 		{
@@ -46,7 +47,7 @@
 					Content = "",
 					LastUpdate = DateTimeOffset.Now
 				};
-			ThisPageTitle = Localizer["sharpsite_newpage"];
+			ThisPageTitle = Localizer[SharedResource.sharpsite_newpage];
 		}
 	}
 

--- a/SharpSite.Web/Components/Admin/EditPost.razor
+++ b/SharpSite.Web/Components/Admin/EditPost.razor
@@ -7,102 +7,91 @@
 @rendermode InteractiveServer
 
 <PageTitle>
-    @if (string.IsNullOrEmpty(Slug))
-    {
-        <text>@Localizer[SharedResource.sharpsite_newpost]</text>
-    }
-    else
-    {
-		<text>@Localizer[SharedResource.sharpsite_editpost]</text>
-    }
+	@Localizer[string.IsNullOrEmpty(Slug) ? SharedResource.sharpsite_newpost : SharedResource.sharpsite_editpost]
 </PageTitle>
 
 <h1>
-    @if (string.IsNullOrEmpty(Slug))
-    {
-        <text>@Localizer[SharedResource.sharpsite_newpost]</text>
-    }
-    else
-    {
-        <text>@Localizer[SharedResource.sharpsite_editpost]</text>
-    }
+	@Localizer[string.IsNullOrEmpty(Slug) ? SharedResource.sharpsite_newpost : SharedResource.sharpsite_editpost]
 </h1>
 
 @if (Post is not null)
 {
-<div class="form-group">
-    <label for="title">@Localizer[SharedResource.sharpsite_editpost_title]</label>
+	<div class="mb-2">
+		<label class="form-label" for="title">@Localizer[SharedResource.sharpsite_editpost_title]</label>
 		<input type="text" class="form-control" id="title" placeholder="@Localizer[SharedResource.sharpsite_editpost_title]" @bind="Post.Title" />
-</div>
+	</div>
 
-@** add a publish date field *@
-<div class="form-group">
-    <label for="publishDate">@Localizer[SharedResource.sharpsite_editpost_publishdate]</label>
-	<input type="date" class="form-control" id="publishDate" @bind="Post.PublishedDate" />
-</div>
+	@** add a publish date field *@
+	<div class="mb-2">
+		<label class="form-label" for="publishDate">@Localizer[SharedResource.sharpsite_editpost_publishdate]</label>
+		<input type="date" class="form-control" id="publishDate" @bind="Post.PublishedDate" />
+	</div>
 
-@** add a textarea for the Post description *@
-<div class="form-group">
-	<label for="description">@Localizer[SharedResource.sharpsite_editpost_description]</label>
-	<textarea class="form-control" id="description" rows="3" @bind="Post.Description"></textarea>
-</div>
+	@** add a textarea for the Post description *@
+	<div class="mb-2">
+		<label class="form-label" for="description">@Localizer[SharedResource.sharpsite_editpost_description]</label>
+		<textarea class="form-control" id="description" rows="3" @bind="Post.Description"></textarea>
+	</div>
 
-<div class="form-group">
-    <label for="content">@Localizer[SharedResource.sharpsite_editpost_content]</label>
-	<TextEditor @bind-Content="@Post.Content" />
-</div>
+	<div class="mb-2">
+		<label class="form-label" for="content">@Localizer[SharedResource.sharpsite_editpost_content]</label>
+		<TextEditor @bind-Content="@Post.Content" />
+	</div>
 
+	<LanguageSelect @bind-Language="@Post.LanguageCode" />
+
+	<div class="mb-2 mb-2">
+		<button type="submit" class="btn btn-primary" @onclick="SavePost">@Localizer[SharedResource.sharpsite_save]</button>
+	</div>
 }
 
-<div class="form-group">
-	<button type="submit" class="btn btn-primary" @onclick="SavePost">@Localizer[SharedResource.sharpsite_save]</button>
-</div>
 @code {
-		[Parameter] public string? Slug { get; set; }
-		[Parameter] public int? UrlDate { get; set; }
+	[Parameter] public string? Slug { get; set; }
+	[Parameter] public int? UrlDate { get; set; }
 
-		private Post? Post { get; set; }
+	private Post? Post { get; set; }
 
-		protected override async Task OnInitializedAsync()
+	protected override async Task OnInitializedAsync()
+	{
+		Post = (await PostService.GetPost(UrlDate?.ToString() ?? string.Empty, Slug ?? string.Empty)) ?? new Post()
 		{
-				Post = (await PostService.GetPost(UrlDate?.ToString() ?? string.Empty, Slug ?? string.Empty)) ?? new Post() {
-					Slug= string.Empty,
-					Content = string.Empty,
-					Title = string.Empty,
-					PublishedDate = DateTime.Now
-				};
+			Slug = string.Empty,
+			Content = string.Empty,
+			Title = string.Empty,
+			PublishedDate = DateTime.Now
+		};
 
+	}
+
+	private async Task SavePost()
+	{
+
+		Console.WriteLine("Save Post");
+
+		if (string.IsNullOrEmpty(Post!.Slug))
+		{
+			Post.Slug = Post.GetSlug(Post.Title);
+			Console.WriteLine(Post.Slug);
+			await PostService.AddPost(Post);
+
+			// flush the outputcache for the sitemap and rss
+			await FlushCache();
+
+			NavManager.NavigateTo("/");
+		}
+		else
+		{
+			await PostService.UpdatePost(Post);
+			await FlushCache();
+			NavManager.NavigateTo("/");
 		}
 
-		private async Task SavePost()
-		{
+	}
 
-				Console.WriteLine("Save Post");	
-
-
-				if (string.IsNullOrEmpty(Post!.Slug))
-				{
-					Post.Slug = Post.GetSlug(Post.Title);
-					Console.WriteLine(Post.Slug);
-					await PostService.AddPost(Post);
-
-					// flush the outputcache for the sitemap and rss
-					await FlushCache();
-
-					NavManager.NavigateTo("/");
-				}
-				else
-				{
-					await PostService.UpdatePost(Post);
-					await FlushCache();
-					NavManager.NavigateTo("/");
-				}
-		}
-
-		private async Task FlushCache()
-		{
-				await OutputCacheStore.EvictByTagAsync("sitemap", CancellationToken.None);
-				await OutputCacheStore.EvictByTagAsync("rss", CancellationToken.None);
-		}
+	private async Task FlushCache()
+	{
+		await OutputCacheStore.EvictByTagAsync("sitemap", CancellationToken.None);
+		await OutputCacheStore.EvictByTagAsync("rss", CancellationToken.None);
+	}
 
 }

--- a/SharpSite.Web/Components/Admin/LanguageSelect.razor
+++ b/SharpSite.Web/Components/Admin/LanguageSelect.razor
@@ -1,0 +1,29 @@
+﻿<div class="form-group mb-2">
+	<label for="language" class="form-label">@Localizer[SharedResource.sharpsite_language_label]</label>
+	<select class="form-select" id="language" @bind:get="Language" @bind:set="SetAsync">
+		@foreach (var culture in _Cultures)
+		{
+			<option value="@culture.Name">@culture.DisplayName (@culture.NativeName)</option>
+		}
+	</select>
+	<small class="text-muted">@Localizer[SharedResource.sharpsite_langauge_help_text]</small>
+</div>
+
+@code {
+	[Parameter]
+	public required string Language { get; set; }
+
+	[Parameter]
+	public EventCallback<string> LanguageChanged { get; set; }
+
+	private async Task SetAsync(string value) => await LanguageChanged.InvokeAsync(value);
+
+	private IEnumerable<CultureInfo> _Cultures { get; set; } = Enumerable.Empty<CultureInfo>();
+
+	protected override void OnInitialized()
+	{
+		_Cultures = CultureInfo.GetCultures(CultureTypes.NeutralCultures).Skip(1); // Skips Invariant Language.
+		base.OnInitialized();
+	}
+}
+

--- a/SharpSite.Web/Components/Pages/DisplayPage.razor
+++ b/SharpSite.Web/Components/Pages/DisplayPage.razor
@@ -4,8 +4,11 @@
 
 @if (Page is not null)
 {
-	<h1>@Page.Title</h1>
-	@((MarkupString)Markdown.ToHtml(Page.Content))
+	<PageTitle>@Page.Title</PageTitle>
+	<div lang="@Page.LanguageCode">
+		<h1>@Page.Title</h1>
+		@((MarkupString)Markdown.ToHtml(Page.Content))
+	</div>
 }
 else
 {

--- a/SharpSite.Web/Components/Pages/PostPage.razor
+++ b/SharpSite.Web/Components/Pages/PostPage.razor
@@ -16,9 +16,11 @@
 @if (Post is not null)
 {
 	<PageTitle>SharpSite &#124; @Post.Title</PageTitle>
-	<h1>@Post.Title</h1>
-	<h6>@Post.PublishedDate.LocalDateTime</h6>
-	<p>@((MarkupString)Markdown.ToHtml(Post.Content))</p>
+	<div lang="@Post.LanguageCode">
+		<h1>@Post.Title</h1>
+		<h6>@Post.PublishedDate.LocalDateTime</h6>
+		<p>@((MarkupString)Markdown.ToHtml(Post.Content))</p>
+	</div>
 }
 else
 {

--- a/SharpSite.Web/Locales/SharedResource.Designer.cs
+++ b/SharpSite.Web/Locales/SharedResource.Designer.cs
@@ -295,6 +295,24 @@ namespace SharpSite.Web.Locales {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to This ensures assistive technologies use the correct language for the content..
+        /// </summary>
+        internal static string sharpsite_langauge_help_text {
+            get {
+                return ResourceManager.GetString("sharpsite_langauge_help_text", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Language.
+        /// </summary>
+        internal static string sharpsite_language_label {
+            get {
+                return ResourceManager.GetString("sharpsite_language_label", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Loading....
         /// </summary>
         internal static string sharpsite_loading {

--- a/SharpSite.Web/Locales/SharedResource.en.resx
+++ b/SharpSite.Web/Locales/SharedResource.en.resx
@@ -319,4 +319,10 @@
   <data name="sharpsite_robotstxt_help_text" xml:space="preserve">
     <value>The file aleady contains the following:</value>
   </data>
+  <data name="sharpsite_language_label" xml:space="preserve">
+    <value>Language</value>
+  </data>
+  <data name="sharpsite_langauge_help_text" xml:space="preserve">
+    <value>This ensures assistive technologies use the correct language for the content.</value>
+  </data>
 </root>

--- a/SharpSite.Web/Locales/SharedResource.fi.resx
+++ b/SharpSite.Web/Locales/SharedResource.fi.resx
@@ -319,4 +319,10 @@
   <data name="sharpsite_robotstxt_help_text" xml:space="preserve">
     <value>Tiedosto sisältää jo seuraavan:</value>
   </data>
+  <data name="sharpsite_language_label" xml:space="preserve">
+    <value>Kieli</value>
+  </data>
+  <data name="sharpsite_langauge_help_text" xml:space="preserve">
+    <value>Tämä varmistaa, että avustavat teknologiat käyttävät sisällölle oikeaa kieltä.</value>
+  </data>
 </root>

--- a/SharpSite.Web/Locales/SharedResource.resx
+++ b/SharpSite.Web/Locales/SharedResource.resx
@@ -335,4 +335,12 @@
     <value>The file aleady contains the following:</value>
     <comment>Help text for robots.txt content admin setting</comment>
   </data>
+  <data name="sharpsite_language_label" xml:space="preserve">
+    <value>Language</value>
+    <comment>Label for language select</comment>
+  </data>
+  <data name="sharpsite_langauge_help_text" xml:space="preserve">
+    <value>This ensures assistive technologies use the correct language for the content.</value>
+    <comment>Help text for language select</comment>
+  </data>
 </root>


### PR DESCRIPTION
Adds `lang` property to the elements wrapping Posts and Pages from their `LanguageCode`.

I used a select element for the `LanguageCode` input. Not sure if it's better than a basic text field.

I manually added commands to the migration to make existing Posts and Pages get "en" `LanguageCode`. Is this ok or should they've been left blank?

Fix FritzAndFriends/sharpsite#187