### PR TITLE
Translated language chooser labels

### DIFF
--- a/src/SharpSite.Web/Locales/SharedResource.bg.resx
+++ b/src/SharpSite.Web/Locales/SharedResource.bg.resx
@@ -360,4 +360,12 @@
   <data name="sharpsite_ChangeTheme">
     <value xml:space="preserve">Промени Темата</value>
   </data>
+  <data name="sharpsite_language_label" xml:space="preserve">
+    <value>Език</value>
+    <comment>AI generated translation</comment>
+  </data>
+  <data name="sharpsite_langauge_help_text" xml:space="preserve">
+    <value>Това гарантира, че помощните технологии използват правилния език за съдържанието.</value>
+    <comment>AI generated translation</comment>
+  </data>
 </root>

--- a/src/SharpSite.Web/Locales/SharedResource.ca.resx
+++ b/src/SharpSite.Web/Locales/SharedResource.ca.resx
@@ -356,4 +356,12 @@
   <data name="sharpsite_ChangeTheme">
     <value xml:space="preserve">Canvia el tema</value>
   </data>
+  <data name="sharpsite_language_label" xml:space="preserve">
+    <value>Idioma</value>
+    <comment>AI generated translation</comment>
+  </data>
+  <data name="sharpsite_langauge_help_text" xml:space="preserve">
+    <value>Això garanteix que les tecnologies d'assistència utilitzin el llenguatge correcte per al contingut.</value>
+    <comment>AI generated translation</comment>
+  </data>
 </root>

--- a/src/SharpSite.Web/Locales/SharedResource.de.resx
+++ b/src/SharpSite.Web/Locales/SharedResource.de.resx
@@ -356,4 +356,12 @@
   <data name="sharpsite_ChangeTheme">
     <value xml:space="preserve">Thema ändern</value>
   </data>
+  <data name="sharpsite_language_label" xml:space="preserve">
+    <value>Sprache</value>
+    <comment>AI generated translation</comment>
+  </data>
+  <data name="sharpsite_langauge_help_text" xml:space="preserve">
+    <value>Dies gewährleistet, dass assistive Technologien die richtige Sprache für den Inhalt verwenden.</value>
+    <comment>AI generated translation</comment>
+  </data>
 </root>

--- a/src/SharpSite.Web/Locales/SharedResource.en.resx
+++ b/src/SharpSite.Web/Locales/SharedResource.en.resx
@@ -329,14 +329,16 @@
   <data name="sharpsite_CustomizePageNotFoundDescription" xml:space="preserve">
     <value>Customize the content for the "page not found" page</value>
   </data>
-   <data name="sharpsite_ChangeTheme" xml:space="preserve">
+  <data name="sharpsite_ChangeTheme" xml:space="preserve">
     <value>Change Theme</value>
     <comment>Text of the button used to change the theme of the website</comment>
   </data>
   <data name="sharpsite_language_label" xml:space="preserve">
     <value>Language</value>
+    <comment>AI generated translation</comment>
   </data>
   <data name="sharpsite_langauge_help_text" xml:space="preserve">
     <value>This ensures assistive technologies use the correct language for the content.</value>
+    <comment>AI generated translation</comment>
   </data>
 </root>

--- a/src/SharpSite.Web/Locales/SharedResource.es.resx
+++ b/src/SharpSite.Web/Locales/SharedResource.es.resx
@@ -356,4 +356,12 @@
   <data name="sharpsite_ChangeTheme">
     <value xml:space="preserve">Cambiar Tema</value>
   </data>
+  <data name="sharpsite_language_label" xml:space="preserve">
+    <value>Idioma</value>
+    <comment>AI generated translation</comment>
+  </data>
+  <data name="sharpsite_langauge_help_text" xml:space="preserve">
+    <value>Esto asegura que las tecnologías de asistencia utilicen el idioma correcto para el contenido.</value>
+    <comment>AI generated translation</comment>
+  </data>
 </root>

--- a/src/SharpSite.Web/Locales/SharedResource.fr.resx
+++ b/src/SharpSite.Web/Locales/SharedResource.fr.resx
@@ -356,4 +356,12 @@
   <data name="sharpsite_ChangeTheme">
     <value xml:space="preserve">Changer de thème</value>
   </data>
+  <data name="sharpsite_language_label" xml:space="preserve">
+    <value>Langue</value>
+    <comment>AI generated translation</comment>
+  </data>
+  <data name="sharpsite_langauge_help_text" xml:space="preserve">
+    <value>Cela garantit que les technologies d'assistance utilisent la langue correcte pour le contenu.</value>
+    <comment>AI generated translation</comment>
+  </data>
 </root>

--- a/src/SharpSite.Web/Locales/SharedResource.it.resx
+++ b/src/SharpSite.Web/Locales/SharedResource.it.resx
@@ -387,4 +387,12 @@
   <data name="sharpsite_ChangeTheme">
     <value xml:space="preserve">Cambia tema</value>
   </data>
+  <data name="sharpsite_language_label" xml:space="preserve">
+    <value>Lingua</value>
+    <comment>AI generated translation</comment>
+  </data>
+  <data name="sharpsite_langauge_help_text" xml:space="preserve">
+    <value>Questo garantisce che le tecnologie assistive utilizzino la lingua corretta per il contenuto.</value>
+    <comment>AI generated translation</comment>
+  </data>
 </root>

--- a/src/SharpSite.Web/Locales/SharedResource.nl.resx
+++ b/src/SharpSite.Web/Locales/SharedResource.nl.resx
@@ -356,4 +356,12 @@
   <data name="sharpsite_ChangeTheme">
     <value xml:space="preserve">Verander thema</value>
   </data>
+  <data name="sharpsite_language_label" xml:space="preserve">
+    <value>Taal</value>
+    <comment>AI generated translation</comment>
+  </data>
+  <data name="sharpsite_langauge_help_text" xml:space="preserve">
+    <value>Dit zorgt ervoor dat hulpmiddelen voor toegankelijkheid de juiste taal gebruiken voor de inhoud.</value>
+    <comment>AI generated translation</comment>
+  </data>
 </root>

--- a/src/SharpSite.Web/Locales/SharedResource.pt.resx
+++ b/src/SharpSite.Web/Locales/SharedResource.pt.resx
@@ -356,4 +356,12 @@
   <data name="sharpsite_ChangeTheme">
     <value xml:space="preserve">Alterar Tema</value>
   </data>
+  <data name="sharpsite_language_label" xml:space="preserve">
+    <value>Idioma</value>
+    <comment>AI generated translation</comment>
+  </data>
+  <data name="sharpsite_langauge_help_text" xml:space="preserve">
+    <value>Isso garante que as tecnologias assistivas usem o idioma correto para o conteúdo.</value>
+    <comment>AI generated translation</comment>
+  </data>
 </root>

--- a/src/SharpSite.Web/Locales/SharedResource.sv.resx
+++ b/src/SharpSite.Web/Locales/SharedResource.sv.resx
@@ -392,4 +392,12 @@
   <data name="sharpsite_ChangeTheme">
     <value xml:space="preserve">Byt tema</value>
   </data>
+  <data name="sharpsite_language_label" xml:space="preserve">
+    <value>Språk</value>
+    <comment>AI generated translation</comment>
+  </data>
+  <data name="sharpsite_langauge_help_text" xml:space="preserve">
+    <value>Detta säkerställer att hjälpmedelstekniker använder rätt språk för innehållet.</value>
+    <comment>AI generated translation</comment>
+  </data>
 </root>

--- a/src/SharpSite.Web/Locales/SharedResource.sw.resx
+++ b/src/SharpSite.Web/Locales/SharedResource.sw.resx
@@ -356,4 +356,12 @@
   <data name="sharpsite_ChangeTheme">
     <value xml:space="preserve">Badili Mandhari</value>
   </data>
+  <data name="sharpsite_language_label" xml:space="preserve">
+    <value>Lugha</value>
+    <comment>AI generated translation</comment>
+  </data>
+  <data name="sharpsite_langauge_help_text" xml:space="preserve">
+    <value>Hii hufanya teknolojia za msaada kutumia lugha sahihi kwa maudhui.</value>
+    <comment>AI generated translation</comment>
+  </data>
 </root>


### PR DESCRIPTION
This pull request includes updates to the localization files for multiple languages in the `src/SharpSite.Web/Locales` directory. The changes add new translations for the language label and help text, with comments indicating that the translations were AI-generated