### PR TITLE
Fix file system name traversal bug

### DIFF
--- a/plugins/SharpSite.Plugins.FileStorage.FileSystem/FileSystemConfigurationSection.cs
+++ b/plugins/SharpSite.Plugins.FileStorage.FileSystem/FileSystemConfigurationSection.cs
@@ -1,4 +1,5 @@
 ﻿using SharpSite.Abstractions.Base;
+using SharpSite.Abstractions.FileStorage;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 
@@ -24,6 +25,7 @@ public class FileSystemConfigurationSection : ISharpSiteConfigurationSection
 			{
 				await pluginManager.MoveDirectoryInPluginsFolder(oldConfig.BaseFolderName, BaseFolderName);
 			}
+			catch (InvalidFolderException) { throw; }
 			catch (Exception)
 			{
 				// typically exiting folder does not exist, so we can just create it

--- a/src/SharpSite.Abstractions.FileStorage/InvalidFolderException.cs
+++ b/src/SharpSite.Abstractions.FileStorage/InvalidFolderException.cs
@@ -1,0 +1,9 @@
+﻿namespace SharpSite.Abstractions.FileStorage;
+public class InvalidFolderException : Exception
+{
+	public InvalidFolderException() : base("Invalid folder location.") { }
+
+	public InvalidFolderException(string message) : base(message) { }
+
+	public InvalidFolderException(string message, Exception innerException) : base(message, innerException) { }
+}

--- a/src/SharpSite.Web/ApplicatonState.cs
+++ b/src/SharpSite.Web/ApplicatonState.cs
@@ -31,7 +31,7 @@ public class ApplicationState
 
 	public Dictionary<string, ISharpSiteConfigurationSection> ConfigurationSections { get; private set; } = new();
 
-	public event EventHandler<ISharpSiteConfigurationSection>? ConfigurationSectionChanged;
+	public event Func<ApplicationState, ISharpSiteConfigurationSection, Task>? ConfigurationSectionChanged;
 
 	/// <summary>
 	/// Maximum file upload size in megabytes.
@@ -138,7 +138,7 @@ public class ApplicationState
 		}
 	}
 
-	public void SetConfigurationSection(ISharpSiteConfigurationSection section)
+	public async Task SetConfigurationSection(ISharpSiteConfigurationSection section)
 	{
 
 		// add a null check for the section argument
@@ -152,7 +152,19 @@ public class ApplicationState
 		{
 			ConfigurationSections.Add(section.SectionName, section);
 		}
-		ConfigurationSectionChanged?.Invoke(this, section);
+
+		if (ConfigurationSectionChanged is not null)
+		{
+			try
+			{
+				await ConfigurationSectionChanged.Invoke(this, section);
+			}
+			catch (Exception)
+			{
+				throw;
+			}
+		}
+
 	}
 
 	private Task PostLoadApplicationState(IServiceProvider services)

--- a/src/SharpSite.Web/Components/Admin/PluginConfigUI.razor
+++ b/src/SharpSite.Web/Components/Admin/PluginConfigUI.razor
@@ -105,7 +105,7 @@ else
 		try
 		{
 			// save the changes to the configuration section
-			AppState.SetConfigurationSection(ConfigurationSection);
+			await AppState.SetConfigurationSection(ConfigurationSection);
 
 			await AppState.Save();
 

--- a/tests/SharpSite.Tests.Web/ApplicationState/SetConfigurationSection/WhenAddingNewSection.cs
+++ b/tests/SharpSite.Tests.Web/ApplicationState/SetConfigurationSection/WhenAddingNewSection.cs
@@ -7,39 +7,39 @@ namespace SharpSite.Tests.Web.ApplicationState.SetConfigurationSection;
 
 public class WhenAddingNewSection : BaseFixture
 {
-    [Fact]
-    public async Task ThenSectionIsAdded()
-    {
-        // Arrange
-        var sectionMock = new Mock<ISharpSiteConfigurationSection>();
-        sectionMock.Setup(s => s.SectionName).Returns("TestSection");
-        var section = sectionMock.Object;
+	[Fact]
+	public async Task ThenSectionIsAdded()
+	{
+		// Arrange
+		var sectionMock = new Mock<ISharpSiteConfigurationSection>();
+		sectionMock.Setup(s => s.SectionName).Returns("TestSection");
+		var section = sectionMock.Object;
 
-        // Act
-        await ApplicationState.SetConfigurationSection(section);
+		// Act
+		await ApplicationState.SetConfigurationSection(section);
 
-        // Assert
-        Assert.Contains(section, ApplicationState.ConfigurationSections.Values);
-    }
+		// Assert
+		Assert.Contains(section, ApplicationState.ConfigurationSections.Values);
+	}
 
-    [Fact]
-    public async Task ThenEventHandlerIsTriggered()
-    {
-        // Arrange
-        var sectionMock = new Mock<ISharpSiteConfigurationSection>();
-        sectionMock.Setup(s => s.SectionName).Returns("TestSection");
-        var section = sectionMock.Object;
-        var eventHandlerTriggered = false;
-        ApplicationState.ConfigurationSectionChanged += async (sender, args) =>
-        {
-            eventHandlerTriggered = true;
-            await Task.CompletedTask;
-        };
+	[Fact]
+	public async Task ThenEventHandlerIsTriggered()
+	{
+		// Arrange
+		var sectionMock = new Mock<ISharpSiteConfigurationSection>();
+		sectionMock.Setup(s => s.SectionName).Returns("TestSection");
+		var section = sectionMock.Object;
+		var eventHandlerTriggered = false;
+		ApplicationState.ConfigurationSectionChanged += async (sender, args) =>
+		{
+			eventHandlerTriggered = true;
+			await Task.CompletedTask;
+		};
 
-        // Act
-        await ApplicationState.SetConfigurationSection(section);
+		// Act
+		await ApplicationState.SetConfigurationSection(section);
 
-        // Assert
-        Assert.True(eventHandlerTriggered);
-    }
+		// Assert
+		Assert.True(eventHandlerTriggered);
+	}
 }

--- a/tests/SharpSite.Tests.Web/ApplicationState/SetConfigurationSection/WhenAddingNewSection.cs
+++ b/tests/SharpSite.Tests.Web/ApplicationState/SetConfigurationSection/WhenAddingNewSection.cs
@@ -7,36 +7,39 @@ namespace SharpSite.Tests.Web.ApplicationState.SetConfigurationSection;
 
 public class WhenAddingNewSection : BaseFixture
 {
-	[Fact]
-	public void ThenSectionIsAdded()
-	{
-		// Arrange
-		var sectionMock = new Mock<ISharpSiteConfigurationSection>();
-		sectionMock.Setup(s => s.SectionName).Returns("TestSection");
-		var section = sectionMock.Object;
+    [Fact]
+    public async Task ThenSectionIsAdded()
+    {
+        // Arrange
+        var sectionMock = new Mock<ISharpSiteConfigurationSection>();
+        sectionMock.Setup(s => s.SectionName).Returns("TestSection");
+        var section = sectionMock.Object;
 
-		// Act
-		ApplicationState.SetConfigurationSection(section);
+        // Act
+        await ApplicationState.SetConfigurationSection(section);
 
-		// Assert
-		Assert.Contains(section, ApplicationState.ConfigurationSections.Values);
-	}
+        // Assert
+        Assert.Contains(section, ApplicationState.ConfigurationSections.Values);
+    }
 
-	[Fact]
-	public void ThenEventHandlerIsTriggered()
-	{
-		// Arrange
-		var sectionMock = new Mock<ISharpSiteConfigurationSection>();
-		sectionMock.Setup(s => s.SectionName).Returns("TestSection");
-		var section = sectionMock.Object;
-		var eventHandlerTriggered = false;
-		ApplicationState.ConfigurationSectionChanged += (sender, args) => eventHandlerTriggered = true;
+    [Fact]
+    public async Task ThenEventHandlerIsTriggered()
+    {
+        // Arrange
+        var sectionMock = new Mock<ISharpSiteConfigurationSection>();
+        sectionMock.Setup(s => s.SectionName).Returns("TestSection");
+        var section = sectionMock.Object;
+        var eventHandlerTriggered = false;
+        ApplicationState.ConfigurationSectionChanged += async (sender, args) =>
+        {
+            eventHandlerTriggered = true;
+            await Task.CompletedTask;
+        };
 
-		// Act
-		ApplicationState.SetConfigurationSection(section);
+        // Act
+        await ApplicationState.SetConfigurationSection(section);
 
-		// Assert
-		Assert.True(eventHandlerTriggered);
-
-	}
+        // Assert
+        Assert.True(eventHandlerTriggered);
+    }
 }

--- a/tests/SharpSite.Tests.Web/ApplicationState/SetConfigurationSection/WhenSettingNullSection.cs
+++ b/tests/SharpSite.Tests.Web/ApplicationState/SetConfigurationSection/WhenSettingNullSection.cs
@@ -5,15 +5,13 @@ namespace SharpSite.Tests.Web.ApplicationState.SetConfigurationSection;
 
 public class WhenSettingNullSection : BaseFixture
 {
+    [Fact]
+    public async Task ThenThrowsArgumentNullException()
+    {
+        // Act
+        async Task Act() => await ApplicationState.SetConfigurationSection(null!);
 
-	[Fact]
-	public void ThenThrowsArgumentNullException()
-	{
-		// Act
-		Action act = () => ApplicationState.SetConfigurationSection(null!);
-
-		// Assert
-		Assert.Throws<ArgumentNullException>(act);
-
-	}
+        // Assert
+        await Assert.ThrowsAsync<ArgumentNullException>(Act);
+    }
 }

--- a/tests/SharpSite.Tests.Web/ApplicationState/SetConfigurationSection/WhenSettingNullSection.cs
+++ b/tests/SharpSite.Tests.Web/ApplicationState/SetConfigurationSection/WhenSettingNullSection.cs
@@ -5,13 +5,13 @@ namespace SharpSite.Tests.Web.ApplicationState.SetConfigurationSection;
 
 public class WhenSettingNullSection : BaseFixture
 {
-    [Fact]
-    public async Task ThenThrowsArgumentNullException()
-    {
-        // Act
-        async Task Act() => await ApplicationState.SetConfigurationSection(null!);
+	[Fact]
+	public async Task ThenThrowsArgumentNullException()
+	{
+		// Act
+		async Task Act() => await ApplicationState.SetConfigurationSection(null!);
 
-        // Assert
-        await Assert.ThrowsAsync<ArgumentNullException>(Act);
-    }
+		// Assert
+		await Assert.ThrowsAsync<ArgumentNullException>(Act);
+	}
 }


### PR DESCRIPTION
Added `IsValidDirectory` to check the directory name in `PluginManager`. I'm not sure if checking reserved names is necessary, but I kept it since Copilot suggested it.

Added an exception `InvalidFolderException` to `SharpSite.Abstractions.FileStorage`. It's used to "communicate" between `PluginManager` and `SharpSite.Plugins.FileStorage.FileSystem`.

Made `ApplicationState.ConfigurationSectionChanged` async to get the error to "bubble" up to `PluginConfigUI`. Otherwise, the directory would not get created, BUT `applicationState.json` would still get updated with the invalid directory name. **Let me know if there is a better way to achieve this.**

Adjusted unit tests accordingly.

Fix #257 