### PR TITLE
Block Duplicate Plugin Uploads

### DIFF
--- a/src/SharpSite.Web/Components/Admin/AddPlugin.razor
+++ b/src/SharpSite.Web/Components/Admin/AddPlugin.razor
@@ -66,6 +66,7 @@
 		catch (Exception ex)
 		{
 			Logger.LogError($"{ex.Message}");
+			PluginManager.CleanupCurrentUploadedPlugin();
 			ErrorMessage = ex.Message;
 		}
 

--- a/src/SharpSite.Web/Locales/SharedResource.Designer.cs
+++ b/src/SharpSite.Web/Locales/SharedResource.Designer.cs
@@ -493,6 +493,15 @@ namespace SharpSite.Web.Locales {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Plugin &apos;{0}&apos; is already installed..
+        /// </summary>
+        internal static string sharpsite_plugin_exists {
+            get {
+                return ResourceManager.GetString("sharpsite_plugin_exists", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Plugin File.
         /// </summary>
         internal static string sharpsite_plugin_file {

--- a/src/SharpSite.Web/Locales/SharedResource.bg.resx
+++ b/src/SharpSite.Web/Locales/SharedResource.bg.resx
@@ -351,15 +351,6 @@
     <value>Файлът вече съдържа следното:</value>
     <comment>AI generated translation</comment>
   </data>
-  <data name="sharpsite_CustomizePageNotFoundHeader" xml:space="preserve">
-    <value xml:space="preserve">Персонализиране на съдържанието на страницата "Не е намерена"</value>
-  </data>
-  <data name="sharpsite_CustomizePageNotFoundDescription" xml:space="preserve">
-    <value xml:space="preserve">Персонализирайте съдържанието за страницата "страницата не е намерена"</value>
-  </data>
-  <data name="sharpsite_ChangeTheme">
-    <value xml:space="preserve">Промени Темата</value>
-  </data>
   <data name="sharpsite_language_label" xml:space="preserve">
     <value>Език</value>
     <comment>AI generated translation</comment>
@@ -367,5 +358,17 @@
   <data name="sharpsite_langauge_help_text" xml:space="preserve">
     <value>Това гарантира, че помощните технологии използват правилния език за съдържанието.</value>
     <comment>AI generated translation</comment>
+  </data>
+  <data name="sharpsite_CustomizePageNotFoundHeader" xml:space="preserve">
+    <value>Персонализиране на съдържанието на страницата "Не е намерена"</value>
+  </data>
+  <data name="sharpsite_CustomizePageNotFoundDescription" xml:space="preserve">
+    <value>Персонализирайте съдържанието за страницата "страницата не е намерена"</value>
+  </data>
+  <data name="sharpsite_ChangeTheme" xml:space="preserve">
+    <value>Промени Темата</value>
+  </data>
+  <data name="sharpsite_plugin_exists" xml:space="preserve">
+    <value />
   </data>
 </root>

--- a/src/SharpSite.Web/Locales/SharedResource.ca.resx
+++ b/src/SharpSite.Web/Locales/SharedResource.ca.resx
@@ -347,15 +347,6 @@
     <value>El fitxer ja conté el següent:</value>
     <comment>AI generated translation</comment>
   </data>
-  <data name="sharpsite_CustomizePageNotFoundHeader" xml:space="preserve">
-    <value xml:space="preserve">Personalitza el contingut de Pàgina no trobada.</value>
-  </data>
-  <data name="sharpsite_CustomizePageNotFoundDescription" xml:space="preserve">
-    <value xml:space="preserve">Personalitzeu el contingut per a la pàgina "pàgina no trobada".</value>
-  </data>
-  <data name="sharpsite_ChangeTheme">
-    <value xml:space="preserve">Canvia el tema</value>
-  </data>
   <data name="sharpsite_language_label" xml:space="preserve">
     <value>Idioma</value>
     <comment>AI generated translation</comment>
@@ -363,5 +354,17 @@
   <data name="sharpsite_langauge_help_text" xml:space="preserve">
     <value>Això garanteix que les tecnologies d'assistència utilitzin el llenguatge correcte per al contingut.</value>
     <comment>AI generated translation</comment>
+  </data>
+  <data name="sharpsite_CustomizePageNotFoundHeader" xml:space="preserve">
+    <value>Personalitza el contingut de Pàgina no trobada.</value>
+  </data>
+  <data name="sharpsite_CustomizePageNotFoundDescription" xml:space="preserve">
+    <value>Personalitzeu el contingut per a la pàgina "pàgina no trobada".</value>
+  </data>
+  <data name="sharpsite_ChangeTheme" xml:space="preserve">
+    <value>Canvia el tema</value>
+  </data>
+  <data name="sharpsite_plugin_exists" xml:space="preserve">
+    <value />
   </data>
 </root>

--- a/src/SharpSite.Web/Locales/SharedResource.de.resx
+++ b/src/SharpSite.Web/Locales/SharedResource.de.resx
@@ -347,15 +347,6 @@
     <value>Die Datei enthält bereits Folgendes:</value>
     <comment>AI generated translation</comment>
   </data>
-  <data name="sharpsite_CustomizePageNotFoundHeader" xml:space="preserve">
-    <value xml:space="preserve">Individualisiere Inhalte für die Seite "Nicht gefunden"</value>
-  </data>
-  <data name="sharpsite_CustomizePageNotFoundDescription" xml:space="preserve">
-    <value xml:space="preserve">Passen Sie den Inhalt für die Seite "Seite nicht gefunden" an.</value>
-  </data>
-  <data name="sharpsite_ChangeTheme">
-    <value xml:space="preserve">Thema ändern</value>
-  </data>
   <data name="sharpsite_language_label" xml:space="preserve">
     <value>Sprache</value>
     <comment>AI generated translation</comment>
@@ -363,5 +354,17 @@
   <data name="sharpsite_langauge_help_text" xml:space="preserve">
     <value>Dies gewährleistet, dass assistive Technologien die richtige Sprache für den Inhalt verwenden.</value>
     <comment>AI generated translation</comment>
+  </data>
+  <data name="sharpsite_CustomizePageNotFoundHeader" xml:space="preserve">
+    <value>Individualisiere Inhalte für die Seite "Nicht gefunden"</value>
+  </data>
+  <data name="sharpsite_CustomizePageNotFoundDescription" xml:space="preserve">
+    <value>Passen Sie den Inhalt für die Seite "Seite nicht gefunden" an.</value>
+  </data>
+  <data name="sharpsite_ChangeTheme" xml:space="preserve">
+    <value>Thema ändern</value>
+  </data>
+  <data name="sharpsite_plugin_exists" xml:space="preserve">
+    <value />
   </data>
 </root>

--- a/src/SharpSite.Web/Locales/SharedResource.en.resx
+++ b/src/SharpSite.Web/Locales/SharedResource.en.resx
@@ -323,6 +323,14 @@
   <data name="sharpsite_robotstxt_help_text" xml:space="preserve">
     <value>The file already contains the following:</value>
   </data>
+  <data name="sharpsite_language_label" xml:space="preserve">
+    <value>Language</value>
+    <comment>AI generated translation</comment>
+  </data>
+  <data name="sharpsite_langauge_help_text" xml:space="preserve">
+    <value>This ensures assistive technologies use the correct language for the content.</value>
+    <comment>AI generated translation</comment>
+  </data>
   <data name="sharpsite_CustomizePageNotFoundHeader" xml:space="preserve">
     <value>Customize Page Not Found content</value>
   </data>
@@ -333,12 +341,7 @@
     <value>Change Theme</value>
     <comment>Text of the button used to change the theme of the website</comment>
   </data>
-  <data name="sharpsite_language_label" xml:space="preserve">
-    <value>Language</value>
-    <comment>AI generated translation</comment>
-  </data>
-  <data name="sharpsite_langauge_help_text" xml:space="preserve">
-    <value>This ensures assistive technologies use the correct language for the content.</value>
-    <comment>AI generated translation</comment>
+  <data name="sharpsite_plugin_exists" xml:space="preserve">
+    <value>Plugin '{0}' is already installed.</value>
   </data>
 </root>

--- a/src/SharpSite.Web/Locales/SharedResource.es.resx
+++ b/src/SharpSite.Web/Locales/SharedResource.es.resx
@@ -347,15 +347,6 @@
     <value>El archivo ya contiene lo siguiente:</value>
     <comment>AI generated translation</comment>
   </data>
-  <data name="sharpsite_CustomizePageNotFoundHeader" xml:space="preserve">
-    <value xml:space="preserve">Personalizar el contenido de la página no encontrada.</value>
-  </data>
-  <data name="sharpsite_CustomizePageNotFoundDescription" xml:space="preserve">
-    <value xml:space="preserve">Personalizar el contenido para la página de "página no encontrada".</value>
-  </data>
-  <data name="sharpsite_ChangeTheme">
-    <value xml:space="preserve">Cambiar Tema</value>
-  </data>
   <data name="sharpsite_language_label" xml:space="preserve">
     <value>Idioma</value>
     <comment>AI generated translation</comment>
@@ -363,5 +354,17 @@
   <data name="sharpsite_langauge_help_text" xml:space="preserve">
     <value>Esto asegura que las tecnologías de asistencia utilicen el idioma correcto para el contenido.</value>
     <comment>AI generated translation</comment>
+  </data>
+  <data name="sharpsite_CustomizePageNotFoundHeader" xml:space="preserve">
+    <value>Personalizar el contenido de la página no encontrada.</value>
+  </data>
+  <data name="sharpsite_CustomizePageNotFoundDescription" xml:space="preserve">
+    <value>Personalizar el contenido para la página de "página no encontrada".</value>
+  </data>
+  <data name="sharpsite_ChangeTheme" xml:space="preserve">
+    <value>Cambiar Tema</value>
+  </data>
+  <data name="sharpsite_plugin_exists" xml:space="preserve">
+    <value />
   </data>
 </root>

--- a/src/SharpSite.Web/Locales/SharedResource.fi.resx
+++ b/src/SharpSite.Web/Locales/SharedResource.fi.resx
@@ -329,12 +329,15 @@
     <value>Tämä varmistaa, että avustavat teknologiat käyttävät sisällölle oikeaa kieltä.</value>
   </data>
   <data name="sharpsite_CustomizePageNotFoundHeader" xml:space="preserve">
-    <value xml:space="preserve">Mukauta Sivua ei löytynyt -sisältöä</value>
+    <value>Mukauta Sivua ei löytynyt -sisältöä</value>
   </data>
   <data name="sharpsite_CustomizePageNotFoundDescription" xml:space="preserve">
-    <value xml:space="preserve">Mukauta sisältö "sivua ei löydy" -sivulle.</value>
+    <value>Mukauta sisältö "sivua ei löydy" -sivulle.</value>
   </data>
-  <data name="sharpsite_ChangeTheme">
-    <value xml:space="preserve">Vaihda teemaa</value>
+  <data name="sharpsite_ChangeTheme" xml:space="preserve">
+    <value>Vaihda teemaa</value>
+  </data>
+  <data name="sharpsite_plugin_exists" xml:space="preserve">
+    <value>Laajennus '{0}' on jo asennettu.</value>
   </data>
 </root>

--- a/src/SharpSite.Web/Locales/SharedResource.fr.resx
+++ b/src/SharpSite.Web/Locales/SharedResource.fr.resx
@@ -347,15 +347,6 @@
     <value>Le fichier contient déjà ce qui suit:</value>
     <comment>AI generated translation</comment>
   </data>
-  <data name="sharpsite_CustomizePageNotFoundHeader" xml:space="preserve">
-    <value xml:space="preserve">Personnaliser le contenu de la page introuvable</value>
-  </data>
-  <data name="sharpsite_CustomizePageNotFoundDescription" xml:space="preserve">
-    <value xml:space="preserve">Personnaliser le contenu de la page "page non trouvée".</value>
-  </data>
-  <data name="sharpsite_ChangeTheme">
-    <value xml:space="preserve">Changer de thème</value>
-  </data>
   <data name="sharpsite_language_label" xml:space="preserve">
     <value>Langue</value>
     <comment>AI generated translation</comment>
@@ -363,5 +354,17 @@
   <data name="sharpsite_langauge_help_text" xml:space="preserve">
     <value>Cela garantit que les technologies d'assistance utilisent la langue correcte pour le contenu.</value>
     <comment>AI generated translation</comment>
+  </data>
+  <data name="sharpsite_CustomizePageNotFoundHeader" xml:space="preserve">
+    <value>Personnaliser le contenu de la page introuvable</value>
+  </data>
+  <data name="sharpsite_CustomizePageNotFoundDescription" xml:space="preserve">
+    <value>Personnaliser le contenu de la page "page non trouvée".</value>
+  </data>
+  <data name="sharpsite_ChangeTheme" xml:space="preserve">
+    <value>Changer de thème</value>
+  </data>
+  <data name="sharpsite_plugin_exists" xml:space="preserve">
+    <value />
   </data>
 </root>

--- a/src/SharpSite.Web/Locales/SharedResource.it.resx
+++ b/src/SharpSite.Web/Locales/SharedResource.it.resx
@@ -378,15 +378,6 @@
     <value>Il file contiene già quanto segue:</value>
     <comment>AI generated translation</comment>
   </data>
-  <data name="sharpsite_CustomizePageNotFoundHeader" xml:space="preserve">
-    <value xml:space="preserve">Personalizza il contenuto della pagina non trovata.</value>
-  </data>
-  <data name="sharpsite_CustomizePageNotFoundDescription" xml:space="preserve">
-    <value xml:space="preserve">Personalizza il contenuto per la pagina "pagina non trovata".</value>
-  </data>
-  <data name="sharpsite_ChangeTheme">
-    <value xml:space="preserve">Cambia tema</value>
-  </data>
   <data name="sharpsite_language_label" xml:space="preserve">
     <value>Lingua</value>
     <comment>AI generated translation</comment>
@@ -394,5 +385,17 @@
   <data name="sharpsite_langauge_help_text" xml:space="preserve">
     <value>Questo garantisce che le tecnologie assistive utilizzino la lingua corretta per il contenuto.</value>
     <comment>AI generated translation</comment>
+  </data>
+  <data name="sharpsite_CustomizePageNotFoundHeader" xml:space="preserve">
+    <value>Personalizza il contenuto della pagina non trovata.</value>
+  </data>
+  <data name="sharpsite_CustomizePageNotFoundDescription" xml:space="preserve">
+    <value>Personalizza il contenuto per la pagina "pagina non trovata".</value>
+  </data>
+  <data name="sharpsite_ChangeTheme" xml:space="preserve">
+    <value>Cambia tema</value>
+  </data>
+  <data name="sharpsite_plugin_exists" xml:space="preserve">
+    <value />
   </data>
 </root>

--- a/src/SharpSite.Web/Locales/SharedResource.nl.resx
+++ b/src/SharpSite.Web/Locales/SharedResource.nl.resx
@@ -347,15 +347,6 @@
     <value>Het bestand bevat al het volgende:</value>
     <comment>AI generated translation</comment>
   </data>
-  <data name="sharpsite_CustomizePageNotFoundHeader" xml:space="preserve">
-    <value xml:space="preserve">Aanpassen van Pagina Niet Gevonden inhoud.</value>
-  </data>
-  <data name="sharpsite_CustomizePageNotFoundDescription" xml:space="preserve">
-    <value xml:space="preserve">Pas de inhoud aan voor de "pagina niet gevonden" pagina.</value>
-  </data>
-  <data name="sharpsite_ChangeTheme">
-    <value xml:space="preserve">Verander thema</value>
-  </data>
   <data name="sharpsite_language_label" xml:space="preserve">
     <value>Taal</value>
     <comment>AI generated translation</comment>
@@ -363,5 +354,17 @@
   <data name="sharpsite_langauge_help_text" xml:space="preserve">
     <value>Dit zorgt ervoor dat hulpmiddelen voor toegankelijkheid de juiste taal gebruiken voor de inhoud.</value>
     <comment>AI generated translation</comment>
+  </data>
+  <data name="sharpsite_CustomizePageNotFoundHeader" xml:space="preserve">
+    <value>Aanpassen van Pagina Niet Gevonden inhoud.</value>
+  </data>
+  <data name="sharpsite_CustomizePageNotFoundDescription" xml:space="preserve">
+    <value>Pas de inhoud aan voor de "pagina niet gevonden" pagina.</value>
+  </data>
+  <data name="sharpsite_ChangeTheme" xml:space="preserve">
+    <value>Verander thema</value>
+  </data>
+  <data name="sharpsite_plugin_exists" xml:space="preserve">
+    <value />
   </data>
 </root>

--- a/src/SharpSite.Web/Locales/SharedResource.pt.resx
+++ b/src/SharpSite.Web/Locales/SharedResource.pt.resx
@@ -347,15 +347,6 @@
     <value>O arquivo já contém o seguinte:</value>
     <comment>AI generated translation</comment>
   </data>
-  <data name="sharpsite_CustomizePageNotFoundHeader" xml:space="preserve">
-    <value xml:space="preserve">Personalizar o conteúdo da página não encontrada.</value>
-  </data>
-  <data name="sharpsite_CustomizePageNotFoundDescription" xml:space="preserve">
-    <value xml:space="preserve">Personalize o conteúdo para a página "página não encontrada"</value>
-  </data>
-  <data name="sharpsite_ChangeTheme">
-    <value xml:space="preserve">Alterar Tema</value>
-  </data>
   <data name="sharpsite_language_label" xml:space="preserve">
     <value>Idioma</value>
     <comment>AI generated translation</comment>
@@ -363,5 +354,17 @@
   <data name="sharpsite_langauge_help_text" xml:space="preserve">
     <value>Isso garante que as tecnologias assistivas usem o idioma correto para o conteúdo.</value>
     <comment>AI generated translation</comment>
+  </data>
+  <data name="sharpsite_CustomizePageNotFoundHeader" xml:space="preserve">
+    <value>Personalizar o conteúdo da página não encontrada.</value>
+  </data>
+  <data name="sharpsite_CustomizePageNotFoundDescription" xml:space="preserve">
+    <value>Personalize o conteúdo para a página "página não encontrada"</value>
+  </data>
+  <data name="sharpsite_ChangeTheme" xml:space="preserve">
+    <value>Alterar Tema</value>
+  </data>
+  <data name="sharpsite_plugin_exists" xml:space="preserve">
+    <value />
   </data>
 </root>

--- a/src/SharpSite.Web/Locales/SharedResource.resx
+++ b/src/SharpSite.Web/Locales/SharedResource.resx
@@ -359,4 +359,8 @@
     <value>Change Theme</value>
     <comment>Text of the button used to change the theme of the website</comment>
   </data>
+  <data name="sharpsite_plugin_exists" xml:space="preserve">
+    <value>Plugin '{0}' is already installed.</value>
+    <comment>Error message to be desplayed when a plugin that already exists, is attempted to be uploaded.</comment>
+  </data>
 </root>

--- a/src/SharpSite.Web/Locales/SharedResource.sv.resx
+++ b/src/SharpSite.Web/Locales/SharedResource.sv.resx
@@ -381,6 +381,14 @@
     <value>Filen innehåller redan följande:</value>
     <comment>AI generated translation</comment>
   </data>
+  <data name="sharpsite_language_label" xml:space="preserve">
+    <value>Språk</value>
+    <comment>AI generated translation</comment>
+  </data>
+  <data name="sharpsite_langauge_help_text" xml:space="preserve">
+    <value>Detta säkerställer att hjälpmedelstekniker använder rätt språk för innehållet.</value>
+    <comment>AI generated translation</comment>
+  </data>
   <data name="sharpsite_CustomizePageNotFoundHeader" xml:space="preserve">
     <value>Anpassa innehållet för 'Sidan kan inte hittas' redigeringskomponenten</value>
     <comment>AI generated translation</comment>
@@ -389,15 +397,10 @@
     <value>Anpassa innehållet för "sida hittades inte"-sidan.</value>
     <comment>AI generated translation</comment>
   </data>
-  <data name="sharpsite_ChangeTheme">
-    <value xml:space="preserve">Byt tema</value>
+  <data name="sharpsite_ChangeTheme" xml:space="preserve">
+    <value>Byt tema</value>
   </data>
-  <data name="sharpsite_language_label" xml:space="preserve">
-    <value>Språk</value>
-    <comment>AI generated translation</comment>
-  </data>
-  <data name="sharpsite_langauge_help_text" xml:space="preserve">
-    <value>Detta säkerställer att hjälpmedelstekniker använder rätt språk för innehållet.</value>
-    <comment>AI generated translation</comment>
+  <data name="sharpsite_plugin_exists" xml:space="preserve">
+    <value />
   </data>
 </root>

--- a/src/SharpSite.Web/Locales/SharedResource.sw.resx
+++ b/src/SharpSite.Web/Locales/SharedResource.sw.resx
@@ -347,15 +347,6 @@
     <value>Faili tayari lina yafuatayo:</value>
     <comment>AI generated translation</comment>
   </data>
-  <data name="sharpsite_CustomizePageNotFoundHeader" xml:space="preserve">
-    <value xml:space="preserve">Sawazisha Yaliyopatikana Ukurasa wa Yaliyopatikana maudhui kwa SharpSite ni mfumo wa usimamizi wa yaliyomo wa chanzo wazi uliojengwa na C# na Blazor.</value>
-  </data>
-  <data name="sharpsite_CustomizePageNotFoundDescription" xml:space="preserve">
-    <value xml:space="preserve">Mbadilishe maudhui ya ukurasa wa "ukurasa haujapatikana" kulingana na mahitaji yako.</value>
-  </data>
-  <data name="sharpsite_ChangeTheme">
-    <value xml:space="preserve">Badili Mandhari</value>
-  </data>
   <data name="sharpsite_language_label" xml:space="preserve">
     <value>Lugha</value>
     <comment>AI generated translation</comment>
@@ -363,5 +354,17 @@
   <data name="sharpsite_langauge_help_text" xml:space="preserve">
     <value>Hii hufanya teknolojia za msaada kutumia lugha sahihi kwa maudhui.</value>
     <comment>AI generated translation</comment>
+  </data>
+  <data name="sharpsite_CustomizePageNotFoundHeader" xml:space="preserve">
+    <value>Sawazisha Yaliyopatikana Ukurasa wa Yaliyopatikana maudhui kwa SharpSite ni mfumo wa usimamizi wa yaliyomo wa chanzo wazi uliojengwa na C# na Blazor.</value>
+  </data>
+  <data name="sharpsite_CustomizePageNotFoundDescription" xml:space="preserve">
+    <value>Mbadilishe maudhui ya ukurasa wa "ukurasa haujapatikana" kulingana na mahitaji yako.</value>
+  </data>
+  <data name="sharpsite_ChangeTheme" xml:space="preserve">
+    <value>Badili Mandhari</value>
+  </data>
+  <data name="sharpsite_plugin_exists" xml:space="preserve">
+    <value />
   </data>
 </root>


### PR DESCRIPTION
I just added a check if the folder, that would be created for the new uploaded plugin, already exists.
If it does, it prevents the user from uploading the plugin.

![image](https://github.com/user-attachments/assets/77aba6d3-f02b-453e-8a80-45ec7286dd70)


Fix FritzAndFriends/SharpSite#141