### PR TITLE
Add a confirmation step if a script tag is detected in post/page markdown content.

### DIFF
--- a/src/SharpSite.Web/Components/Admin/ConfirmSaveButton.razor
+++ b/src/SharpSite.Web/Components/Admin/ConfirmSaveButton.razor
@@ -1,0 +1,26 @@
+﻿<div class="mb-2 mb-2">
+	@if (!ConfirmationRequired)
+	{
+		<button type="submit" class="btn btn-primary" @onclick="SaveCallback">@SharedResource.sharpsite_save</button>
+	}
+	else
+	{
+		<div class="alert alert-danger" role="alert">@AlertMessage</div>
+		<button type="submit" class="btn btn-primary" @onclick="SaveCallback">@SharedResource.sharpsite_confirm</button>
+		<button type="button" class="btn btn-danger" @onclick="CancelCallback">@SharedResource.sharpsite_cancel</button>
+	}
+</div>
+
+@code {
+	[Parameter, EditorRequired]
+	public required string AlertMessage { get; set; }
+
+	[Parameter, EditorRequired]
+	public required bool ConfirmationRequired { get; set; }
+
+	[Parameter, EditorRequired]
+	public required EventCallback SaveCallback { get; set; }
+
+	[Parameter, EditorRequired]
+	public required EventCallback CancelCallback { get; set; }
+}

--- a/src/SharpSite.Web/Components/Admin/EditPage.razor
+++ b/src/SharpSite.Web/Components/Admin/EditPage.razor
@@ -17,10 +17,14 @@
 	<div class="mb-2">
 		<label for="content">@Localizer[SharedResource.sharpsite_editpost_content]</label>
 		<br />
-			<TextEditor @bind-Content="@Page.Content" AlignmentOptionsEnabled="true" />
+		<TextEditor @bind-Content="@Page.Content" AlignmentOptionsEnabled="true" />
 	</div>
 	<LanguageSelect @bind-Language="@Page.LanguageCode" />
-	<button class="btn btn-primary mb-2" @onclick="SavePage">@Localizer[SharedResource.sharpsite_save]</button>
+	<ConfirmSaveButton
+		AlertMessage="@SharedResource.sharpsite_script_alert_page"
+		ConfirmationRequired="_ConfirmationRequired"
+		SaveCallback="SavePage"
+		CancelCallback="() => _ConfirmationRequired = false" />
 }
 
 @code {
@@ -30,6 +34,8 @@
 	private Page? Page { get; set; }
 
 	private string ThisPageTitle = string.Empty;
+
+	private bool _ConfirmationRequired = false;
 
 	protected override async Task OnInitializedAsync()
 	{
@@ -54,6 +60,12 @@
 	private async Task SavePage()
 	{
 
+		if (!_ConfirmationRequired && MarkdownHelper.ContainsScriptTag(Page!.Content))
+		{
+			_ConfirmationRequired = true;
+			return;
+		}
+
 		if (Id == 0)
 		{
 			// format and set the slug based on the title
@@ -67,5 +79,6 @@
 			await PageRepository.UpdatePage(Page!);
 		}
 		NavManager.NavigateTo("/admin/Pages");
+
 	}
 }

--- a/src/SharpSite.Web/Components/Admin/EditPost.razor
+++ b/src/SharpSite.Web/Components/Admin/EditPost.razor
@@ -35,14 +35,16 @@
 
 	<div class="mb-2">
 		<label class="form-label" for="content">@Localizer[SharedResource.sharpsite_editpost_content]</label>
-			<TextEditor @bind-Content="@Post.Content" AlignmentOptionsEnabled="true" />
+		<TextEditor @bind-Content="@Post.Content" AlignmentOptionsEnabled="true" />
 	</div>
 
 	<LanguageSelect @bind-Language="@Post.LanguageCode" />
 
-	<div class="mb-2 mb-2">
-		<button type="submit" name="saveS" class="btn btn-primary" @onclick="SavePost">@Localizer[SharedResource.sharpsite_save]</button>
-	</div>
+	<ConfirmSaveButton
+		AlertMessage="@SharedResource.sharpsite_script_alert_page"
+		ConfirmationRequired="_ConfirmationRequired"
+		SaveCallback="SavePost"
+		CancelCallback="() => _ConfirmationRequired = false" />
 }
 
 @code {
@@ -50,6 +52,7 @@
 	[Parameter] public int? UrlDate { get; set; }
 
 	private Post? Post { get; set; }
+	private bool _ConfirmationRequired = false;
 
 	protected override async Task OnInitializedAsync()
 	{
@@ -66,25 +69,23 @@
 	private async Task SavePost()
 	{
 
-		Console.WriteLine("Save Post");
+		if (!_ConfirmationRequired && MarkdownHelper.ContainsScriptTag(Post!.Content))
+		{
+			_ConfirmationRequired = true;
+			return;
+		}
 
 		if (string.IsNullOrEmpty(Post!.Slug))
 		{
 			Post.Slug = Post.GetSlug(Post.Title);
-			Console.WriteLine(Post.Slug);
 			await PostService.AddPost(Post);
-
-			// flush the outputcache for the sitemap and rss
-			await FlushCache();
-
-			NavManager.NavigateTo("/admin/posts");
 		}
 		else
 		{
 			await PostService.UpdatePost(Post);
-			await FlushCache();
-			NavManager.NavigateTo("/admin/posts");
 		}
+		await FlushCache();
+		NavManager.NavigateTo("/admin/posts");
 
 	}
 

--- a/src/SharpSite.Web/Locales/SharedResource.Designer.cs
+++ b/src/SharpSite.Web/Locales/SharedResource.Designer.cs
@@ -151,11 +151,29 @@ namespace SharpSite.Web.Locales {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Cancel.
+        /// </summary>
+        internal static string sharpsite_cancel {
+            get {
+                return ResourceManager.GetString("sharpsite_cancel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Change Theme.
         /// </summary>
         internal static string sharpsite_ChangeTheme {
             get {
                 return ResourceManager.GetString("sharpsite_ChangeTheme", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Confirm.
+        /// </summary>
+        internal static string sharpsite_confirm {
+            get {
+                return ResourceManager.GetString("sharpsite_confirm", resourceCulture);
             }
         }
         
@@ -624,6 +642,24 @@ namespace SharpSite.Web.Locales {
         internal static string sharpsite_save {
             get {
                 return ResourceManager.GetString("sharpsite_save", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The markdown contains a script tag which will be executed once users load the page. Are you sure you want to proceed?.
+        /// </summary>
+        internal static string sharpsite_script_alert_page {
+            get {
+                return ResourceManager.GetString("sharpsite_script_alert_page", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The markdown contains a script tag which will be executed once users load the post. Are you sure you want to proceed?.
+        /// </summary>
+        internal static string sharpsite_script_alert_post {
+            get {
+                return ResourceManager.GetString("sharpsite_script_alert_post", resourceCulture);
             }
         }
         

--- a/src/SharpSite.Web/Locales/SharedResource.bg.resx
+++ b/src/SharpSite.Web/Locales/SharedResource.bg.resx
@@ -351,15 +351,6 @@
     <value>Файлът вече съдържа следното:</value>
     <comment>AI generated translation</comment>
   </data>
-  <data name="sharpsite_CustomizePageNotFoundHeader" xml:space="preserve">
-    <value xml:space="preserve">Персонализиране на съдържанието на страницата "Не е намерена"</value>
-  </data>
-  <data name="sharpsite_CustomizePageNotFoundDescription" xml:space="preserve">
-    <value xml:space="preserve">Персонализирайте съдържанието за страницата "страницата не е намерена"</value>
-  </data>
-  <data name="sharpsite_ChangeTheme">
-    <value xml:space="preserve">Промени Темата</value>
-  </data>
   <data name="sharpsite_language_label" xml:space="preserve">
     <value>Език</value>
     <comment>AI generated translation</comment>
@@ -367,5 +358,26 @@
   <data name="sharpsite_langauge_help_text" xml:space="preserve">
     <value>Това гарантира, че помощните технологии използват правилния език за съдържанието.</value>
     <comment>AI generated translation</comment>
+  </data>
+  <data name="sharpsite_CustomizePageNotFoundHeader" xml:space="preserve">
+    <value>Персонализиране на съдържанието на страницата "Не е намерена"</value>
+  </data>
+  <data name="sharpsite_CustomizePageNotFoundDescription" xml:space="preserve">
+    <value>Персонализирайте съдържанието за страницата "страницата не е намерена"</value>
+  </data>
+  <data name="sharpsite_ChangeTheme" xml:space="preserve">
+    <value>Промени Темата</value>
+  </data>
+  <data name="sharpsite_script_alert_page" xml:space="preserve">
+    <value />
+  </data>
+  <data name="sharpsite_script_alert_post" xml:space="preserve">
+    <value />
+  </data>
+  <data name="sharpsite_confirm" xml:space="preserve">
+    <value />
+  </data>
+  <data name="sharpsite_cancel" xml:space="preserve">
+    <value />
   </data>
 </root>

--- a/src/SharpSite.Web/Locales/SharedResource.ca.resx
+++ b/src/SharpSite.Web/Locales/SharedResource.ca.resx
@@ -347,15 +347,6 @@
     <value>El fitxer ja conté el següent:</value>
     <comment>AI generated translation</comment>
   </data>
-  <data name="sharpsite_CustomizePageNotFoundHeader" xml:space="preserve">
-    <value xml:space="preserve">Personalitza el contingut de Pàgina no trobada.</value>
-  </data>
-  <data name="sharpsite_CustomizePageNotFoundDescription" xml:space="preserve">
-    <value xml:space="preserve">Personalitzeu el contingut per a la pàgina "pàgina no trobada".</value>
-  </data>
-  <data name="sharpsite_ChangeTheme">
-    <value xml:space="preserve">Canvia el tema</value>
-  </data>
   <data name="sharpsite_language_label" xml:space="preserve">
     <value>Idioma</value>
     <comment>AI generated translation</comment>
@@ -363,5 +354,26 @@
   <data name="sharpsite_langauge_help_text" xml:space="preserve">
     <value>Això garanteix que les tecnologies d'assistència utilitzin el llenguatge correcte per al contingut.</value>
     <comment>AI generated translation</comment>
+  </data>
+  <data name="sharpsite_CustomizePageNotFoundHeader" xml:space="preserve">
+    <value>Personalitza el contingut de Pàgina no trobada.</value>
+  </data>
+  <data name="sharpsite_CustomizePageNotFoundDescription" xml:space="preserve">
+    <value>Personalitzeu el contingut per a la pàgina "pàgina no trobada".</value>
+  </data>
+  <data name="sharpsite_ChangeTheme" xml:space="preserve">
+    <value>Canvia el tema</value>
+  </data>
+  <data name="sharpsite_script_alert_page" xml:space="preserve">
+    <value />
+  </data>
+  <data name="sharpsite_script_alert_post" xml:space="preserve">
+    <value />
+  </data>
+  <data name="sharpsite_confirm" xml:space="preserve">
+    <value />
+  </data>
+  <data name="sharpsite_cancel" xml:space="preserve">
+    <value />
   </data>
 </root>

--- a/src/SharpSite.Web/Locales/SharedResource.de.resx
+++ b/src/SharpSite.Web/Locales/SharedResource.de.resx
@@ -347,15 +347,6 @@
     <value>Die Datei enthält bereits Folgendes:</value>
     <comment>AI generated translation</comment>
   </data>
-  <data name="sharpsite_CustomizePageNotFoundHeader" xml:space="preserve">
-    <value xml:space="preserve">Individualisiere Inhalte für die Seite "Nicht gefunden"</value>
-  </data>
-  <data name="sharpsite_CustomizePageNotFoundDescription" xml:space="preserve">
-    <value xml:space="preserve">Passen Sie den Inhalt für die Seite "Seite nicht gefunden" an.</value>
-  </data>
-  <data name="sharpsite_ChangeTheme">
-    <value xml:space="preserve">Thema ändern</value>
-  </data>
   <data name="sharpsite_language_label" xml:space="preserve">
     <value>Sprache</value>
     <comment>AI generated translation</comment>
@@ -363,5 +354,26 @@
   <data name="sharpsite_langauge_help_text" xml:space="preserve">
     <value>Dies gewährleistet, dass assistive Technologien die richtige Sprache für den Inhalt verwenden.</value>
     <comment>AI generated translation</comment>
+  </data>
+  <data name="sharpsite_CustomizePageNotFoundHeader" xml:space="preserve">
+    <value>Individualisiere Inhalte für die Seite "Nicht gefunden"</value>
+  </data>
+  <data name="sharpsite_CustomizePageNotFoundDescription" xml:space="preserve">
+    <value>Passen Sie den Inhalt für die Seite "Seite nicht gefunden" an.</value>
+  </data>
+  <data name="sharpsite_ChangeTheme" xml:space="preserve">
+    <value>Thema ändern</value>
+  </data>
+  <data name="sharpsite_script_alert_page" xml:space="preserve">
+    <value />
+  </data>
+  <data name="sharpsite_script_alert_post" xml:space="preserve">
+    <value />
+  </data>
+  <data name="sharpsite_confirm" xml:space="preserve">
+    <value />
+  </data>
+  <data name="sharpsite_cancel" xml:space="preserve">
+    <value />
   </data>
 </root>

--- a/src/SharpSite.Web/Locales/SharedResource.en.resx
+++ b/src/SharpSite.Web/Locales/SharedResource.en.resx
@@ -323,6 +323,14 @@
   <data name="sharpsite_robotstxt_help_text" xml:space="preserve">
     <value>The file already contains the following:</value>
   </data>
+  <data name="sharpsite_language_label" xml:space="preserve">
+    <value>Language</value>
+    <comment>AI generated translation</comment>
+  </data>
+  <data name="sharpsite_langauge_help_text" xml:space="preserve">
+    <value>This ensures assistive technologies use the correct language for the content.</value>
+    <comment>AI generated translation</comment>
+  </data>
   <data name="sharpsite_CustomizePageNotFoundHeader" xml:space="preserve">
     <value>Customize Page Not Found content</value>
   </data>
@@ -333,12 +341,16 @@
     <value>Change Theme</value>
     <comment>Text of the button used to change the theme of the website</comment>
   </data>
-  <data name="sharpsite_language_label" xml:space="preserve">
-    <value>Language</value>
-    <comment>AI generated translation</comment>
+  <data name="sharpsite_script_alert_page" xml:space="preserve">
+    <value>The markdown contains a script tag which will be executed once users load the page. Are you sure you want to proceed?</value>
   </data>
-  <data name="sharpsite_langauge_help_text" xml:space="preserve">
-    <value>This ensures assistive technologies use the correct language for the content.</value>
-    <comment>AI generated translation</comment>
+  <data name="sharpsite_script_alert_post" xml:space="preserve">
+    <value>The markdown contains a script tag which will be executed once users load the post. Are you sure you want to proceed?</value>
+  </data>
+  <data name="sharpsite_confirm" xml:space="preserve">
+    <value>Confirm</value>
+  </data>
+  <data name="sharpsite_cancel" xml:space="preserve">
+    <value>Cancel</value>
   </data>
 </root>

--- a/src/SharpSite.Web/Locales/SharedResource.es.resx
+++ b/src/SharpSite.Web/Locales/SharedResource.es.resx
@@ -347,15 +347,6 @@
     <value>El archivo ya contiene lo siguiente:</value>
     <comment>AI generated translation</comment>
   </data>
-  <data name="sharpsite_CustomizePageNotFoundHeader" xml:space="preserve">
-    <value xml:space="preserve">Personalizar el contenido de la página no encontrada.</value>
-  </data>
-  <data name="sharpsite_CustomizePageNotFoundDescription" xml:space="preserve">
-    <value xml:space="preserve">Personalizar el contenido para la página de "página no encontrada".</value>
-  </data>
-  <data name="sharpsite_ChangeTheme">
-    <value xml:space="preserve">Cambiar Tema</value>
-  </data>
   <data name="sharpsite_language_label" xml:space="preserve">
     <value>Idioma</value>
     <comment>AI generated translation</comment>
@@ -363,5 +354,26 @@
   <data name="sharpsite_langauge_help_text" xml:space="preserve">
     <value>Esto asegura que las tecnologías de asistencia utilicen el idioma correcto para el contenido.</value>
     <comment>AI generated translation</comment>
+  </data>
+  <data name="sharpsite_CustomizePageNotFoundHeader" xml:space="preserve">
+    <value>Personalizar el contenido de la página no encontrada.</value>
+  </data>
+  <data name="sharpsite_CustomizePageNotFoundDescription" xml:space="preserve">
+    <value>Personalizar el contenido para la página de "página no encontrada".</value>
+  </data>
+  <data name="sharpsite_ChangeTheme" xml:space="preserve">
+    <value>Cambiar Tema</value>
+  </data>
+  <data name="sharpsite_script_alert_page" xml:space="preserve">
+    <value />
+  </data>
+  <data name="sharpsite_script_alert_post" xml:space="preserve">
+    <value />
+  </data>
+  <data name="sharpsite_confirm" xml:space="preserve">
+    <value />
+  </data>
+  <data name="sharpsite_cancel" xml:space="preserve">
+    <value />
   </data>
 </root>

--- a/src/SharpSite.Web/Locales/SharedResource.fi.resx
+++ b/src/SharpSite.Web/Locales/SharedResource.fi.resx
@@ -329,12 +329,24 @@
     <value>Tämä varmistaa, että avustavat teknologiat käyttävät sisällölle oikeaa kieltä.</value>
   </data>
   <data name="sharpsite_CustomizePageNotFoundHeader" xml:space="preserve">
-    <value xml:space="preserve">Mukauta Sivua ei löytynyt -sisältöä</value>
+    <value>Mukauta Sivua ei löytynyt -sisältöä</value>
   </data>
   <data name="sharpsite_CustomizePageNotFoundDescription" xml:space="preserve">
-    <value xml:space="preserve">Mukauta sisältö "sivua ei löydy" -sivulle.</value>
+    <value>Mukauta sisältö "sivua ei löydy" -sivulle.</value>
   </data>
-  <data name="sharpsite_ChangeTheme">
-    <value xml:space="preserve">Vaihda teemaa</value>
+  <data name="sharpsite_ChangeTheme" xml:space="preserve">
+    <value>Vaihda teemaa</value>
+  </data>
+  <data name="sharpsite_script_alert_page" xml:space="preserve">
+    <value>Markdown sisältää script -tagin, joka ajetaan, kun käyttäjät lataavat sivun. Oletko varma, että haluat jatkaa?</value>
+  </data>
+  <data name="sharpsite_script_alert_post" xml:space="preserve">
+    <value>Markdown sisältää script -tagin, joka ajetaan, kun käyttäjät lataavat postauksen. Oletko varma, että haluat jatkaa?</value>
+  </data>
+  <data name="sharpsite_confirm" xml:space="preserve">
+    <value>Vahvista</value>
+  </data>
+  <data name="sharpsite_cancel" xml:space="preserve">
+    <value>Peruuta</value>
   </data>
 </root>

--- a/src/SharpSite.Web/Locales/SharedResource.fr.resx
+++ b/src/SharpSite.Web/Locales/SharedResource.fr.resx
@@ -347,15 +347,6 @@
     <value>Le fichier contient déjà ce qui suit:</value>
     <comment>AI generated translation</comment>
   </data>
-  <data name="sharpsite_CustomizePageNotFoundHeader" xml:space="preserve">
-    <value xml:space="preserve">Personnaliser le contenu de la page introuvable</value>
-  </data>
-  <data name="sharpsite_CustomizePageNotFoundDescription" xml:space="preserve">
-    <value xml:space="preserve">Personnaliser le contenu de la page "page non trouvée".</value>
-  </data>
-  <data name="sharpsite_ChangeTheme">
-    <value xml:space="preserve">Changer de thème</value>
-  </data>
   <data name="sharpsite_language_label" xml:space="preserve">
     <value>Langue</value>
     <comment>AI generated translation</comment>
@@ -363,5 +354,26 @@
   <data name="sharpsite_langauge_help_text" xml:space="preserve">
     <value>Cela garantit que les technologies d'assistance utilisent la langue correcte pour le contenu.</value>
     <comment>AI generated translation</comment>
+  </data>
+  <data name="sharpsite_CustomizePageNotFoundHeader" xml:space="preserve">
+    <value>Personnaliser le contenu de la page introuvable</value>
+  </data>
+  <data name="sharpsite_CustomizePageNotFoundDescription" xml:space="preserve">
+    <value>Personnaliser le contenu de la page "page non trouvée".</value>
+  </data>
+  <data name="sharpsite_ChangeTheme" xml:space="preserve">
+    <value>Changer de thème</value>
+  </data>
+  <data name="sharpsite_script_alert_page" xml:space="preserve">
+    <value />
+  </data>
+  <data name="sharpsite_script_alert_post" xml:space="preserve">
+    <value />
+  </data>
+  <data name="sharpsite_confirm" xml:space="preserve">
+    <value />
+  </data>
+  <data name="sharpsite_cancel" xml:space="preserve">
+    <value />
   </data>
 </root>

--- a/src/SharpSite.Web/Locales/SharedResource.it.resx
+++ b/src/SharpSite.Web/Locales/SharedResource.it.resx
@@ -378,15 +378,6 @@
     <value>Il file contiene già quanto segue:</value>
     <comment>AI generated translation</comment>
   </data>
-  <data name="sharpsite_CustomizePageNotFoundHeader" xml:space="preserve">
-    <value xml:space="preserve">Personalizza il contenuto della pagina non trovata.</value>
-  </data>
-  <data name="sharpsite_CustomizePageNotFoundDescription" xml:space="preserve">
-    <value xml:space="preserve">Personalizza il contenuto per la pagina "pagina non trovata".</value>
-  </data>
-  <data name="sharpsite_ChangeTheme">
-    <value xml:space="preserve">Cambia tema</value>
-  </data>
   <data name="sharpsite_language_label" xml:space="preserve">
     <value>Lingua</value>
     <comment>AI generated translation</comment>
@@ -394,5 +385,26 @@
   <data name="sharpsite_langauge_help_text" xml:space="preserve">
     <value>Questo garantisce che le tecnologie assistive utilizzino la lingua corretta per il contenuto.</value>
     <comment>AI generated translation</comment>
+  </data>
+  <data name="sharpsite_CustomizePageNotFoundHeader" xml:space="preserve">
+    <value>Personalizza il contenuto della pagina non trovata.</value>
+  </data>
+  <data name="sharpsite_CustomizePageNotFoundDescription" xml:space="preserve">
+    <value>Personalizza il contenuto per la pagina "pagina non trovata".</value>
+  </data>
+  <data name="sharpsite_ChangeTheme" xml:space="preserve">
+    <value>Cambia tema</value>
+  </data>
+  <data name="sharpsite_script_alert_page" xml:space="preserve">
+    <value />
+  </data>
+  <data name="sharpsite_script_alert_post" xml:space="preserve">
+    <value />
+  </data>
+  <data name="sharpsite_confirm" xml:space="preserve">
+    <value />
+  </data>
+  <data name="sharpsite_cancel" xml:space="preserve">
+    <value />
   </data>
 </root>

--- a/src/SharpSite.Web/Locales/SharedResource.nl.resx
+++ b/src/SharpSite.Web/Locales/SharedResource.nl.resx
@@ -347,15 +347,6 @@
     <value>Het bestand bevat al het volgende:</value>
     <comment>AI generated translation</comment>
   </data>
-  <data name="sharpsite_CustomizePageNotFoundHeader" xml:space="preserve">
-    <value xml:space="preserve">Aanpassen van Pagina Niet Gevonden inhoud.</value>
-  </data>
-  <data name="sharpsite_CustomizePageNotFoundDescription" xml:space="preserve">
-    <value xml:space="preserve">Pas de inhoud aan voor de "pagina niet gevonden" pagina.</value>
-  </data>
-  <data name="sharpsite_ChangeTheme">
-    <value xml:space="preserve">Verander thema</value>
-  </data>
   <data name="sharpsite_language_label" xml:space="preserve">
     <value>Taal</value>
     <comment>AI generated translation</comment>
@@ -363,5 +354,26 @@
   <data name="sharpsite_langauge_help_text" xml:space="preserve">
     <value>Dit zorgt ervoor dat hulpmiddelen voor toegankelijkheid de juiste taal gebruiken voor de inhoud.</value>
     <comment>AI generated translation</comment>
+  </data>
+  <data name="sharpsite_CustomizePageNotFoundHeader" xml:space="preserve">
+    <value>Aanpassen van Pagina Niet Gevonden inhoud.</value>
+  </data>
+  <data name="sharpsite_CustomizePageNotFoundDescription" xml:space="preserve">
+    <value>Pas de inhoud aan voor de "pagina niet gevonden" pagina.</value>
+  </data>
+  <data name="sharpsite_ChangeTheme" xml:space="preserve">
+    <value>Verander thema</value>
+  </data>
+  <data name="sharpsite_script_alert_page" xml:space="preserve">
+    <value />
+  </data>
+  <data name="sharpsite_script_alert_post" xml:space="preserve">
+    <value />
+  </data>
+  <data name="sharpsite_confirm" xml:space="preserve">
+    <value />
+  </data>
+  <data name="sharpsite_cancel" xml:space="preserve">
+    <value />
   </data>
 </root>

--- a/src/SharpSite.Web/Locales/SharedResource.pt.resx
+++ b/src/SharpSite.Web/Locales/SharedResource.pt.resx
@@ -347,15 +347,6 @@
     <value>O arquivo já contém o seguinte:</value>
     <comment>AI generated translation</comment>
   </data>
-  <data name="sharpsite_CustomizePageNotFoundHeader" xml:space="preserve">
-    <value xml:space="preserve">Personalizar o conteúdo da página não encontrada.</value>
-  </data>
-  <data name="sharpsite_CustomizePageNotFoundDescription" xml:space="preserve">
-    <value xml:space="preserve">Personalize o conteúdo para a página "página não encontrada"</value>
-  </data>
-  <data name="sharpsite_ChangeTheme">
-    <value xml:space="preserve">Alterar Tema</value>
-  </data>
   <data name="sharpsite_language_label" xml:space="preserve">
     <value>Idioma</value>
     <comment>AI generated translation</comment>
@@ -363,5 +354,26 @@
   <data name="sharpsite_langauge_help_text" xml:space="preserve">
     <value>Isso garante que as tecnologias assistivas usem o idioma correto para o conteúdo.</value>
     <comment>AI generated translation</comment>
+  </data>
+  <data name="sharpsite_CustomizePageNotFoundHeader" xml:space="preserve">
+    <value>Personalizar o conteúdo da página não encontrada.</value>
+  </data>
+  <data name="sharpsite_CustomizePageNotFoundDescription" xml:space="preserve">
+    <value>Personalize o conteúdo para a página "página não encontrada"</value>
+  </data>
+  <data name="sharpsite_ChangeTheme" xml:space="preserve">
+    <value>Alterar Tema</value>
+  </data>
+  <data name="sharpsite_script_alert_page" xml:space="preserve">
+    <value />
+  </data>
+  <data name="sharpsite_script_alert_post" xml:space="preserve">
+    <value />
+  </data>
+  <data name="sharpsite_confirm" xml:space="preserve">
+    <value />
+  </data>
+  <data name="sharpsite_cancel" xml:space="preserve">
+    <value />
   </data>
 </root>

--- a/src/SharpSite.Web/Locales/SharedResource.resx
+++ b/src/SharpSite.Web/Locales/SharedResource.resx
@@ -359,4 +359,20 @@
     <value>Change Theme</value>
     <comment>Text of the button used to change the theme of the website</comment>
   </data>
+  <data name="sharpsite_script_alert_page" xml:space="preserve">
+    <value>The markdown contains a script tag which will be executed once users load the page. Are you sure you want to proceed?</value>
+    <comment>Alert message that is showed when the markdown content for a page contains a script tag</comment>
+  </data>
+  <data name="sharpsite_script_alert_post" xml:space="preserve">
+    <value>The markdown contains a script tag which will be executed once users load the post. Are you sure you want to proceed?</value>
+    <comment>Alert message that is showed when the markdown content for a post contains a script tag</comment>
+  </data>
+  <data name="sharpsite_confirm" xml:space="preserve">
+    <value>Confirm</value>
+    <comment>To confirm an action</comment>
+  </data>
+  <data name="sharpsite_cancel" xml:space="preserve">
+    <value>Cancel</value>
+    <comment>To cancel an action</comment>
+  </data>
 </root>

--- a/src/SharpSite.Web/Locales/SharedResource.sv.resx
+++ b/src/SharpSite.Web/Locales/SharedResource.sv.resx
@@ -381,6 +381,14 @@
     <value>Filen innehåller redan följande:</value>
     <comment>AI generated translation</comment>
   </data>
+  <data name="sharpsite_language_label" xml:space="preserve">
+    <value>Språk</value>
+    <comment>AI generated translation</comment>
+  </data>
+  <data name="sharpsite_langauge_help_text" xml:space="preserve">
+    <value>Detta säkerställer att hjälpmedelstekniker använder rätt språk för innehållet.</value>
+    <comment>AI generated translation</comment>
+  </data>
   <data name="sharpsite_CustomizePageNotFoundHeader" xml:space="preserve">
     <value>Anpassa innehållet för 'Sidan kan inte hittas' redigeringskomponenten</value>
     <comment>AI generated translation</comment>
@@ -389,15 +397,19 @@
     <value>Anpassa innehållet för "sida hittades inte"-sidan.</value>
     <comment>AI generated translation</comment>
   </data>
-  <data name="sharpsite_ChangeTheme">
-    <value xml:space="preserve">Byt tema</value>
+  <data name="sharpsite_ChangeTheme" xml:space="preserve">
+    <value>Byt tema</value>
   </data>
-  <data name="sharpsite_language_label" xml:space="preserve">
-    <value>Språk</value>
-    <comment>AI generated translation</comment>
+  <data name="sharpsite_script_alert_page" xml:space="preserve">
+    <value />
   </data>
-  <data name="sharpsite_langauge_help_text" xml:space="preserve">
-    <value>Detta säkerställer att hjälpmedelstekniker använder rätt språk för innehållet.</value>
-    <comment>AI generated translation</comment>
+  <data name="sharpsite_script_alert_post" xml:space="preserve">
+    <value />
+  </data>
+  <data name="sharpsite_confirm" xml:space="preserve">
+    <value />
+  </data>
+  <data name="sharpsite_cancel" xml:space="preserve">
+    <value />
   </data>
 </root>

--- a/src/SharpSite.Web/Locales/SharedResource.sw.resx
+++ b/src/SharpSite.Web/Locales/SharedResource.sw.resx
@@ -347,15 +347,6 @@
     <value>Faili tayari lina yafuatayo:</value>
     <comment>AI generated translation</comment>
   </data>
-  <data name="sharpsite_CustomizePageNotFoundHeader" xml:space="preserve">
-    <value xml:space="preserve">Sawazisha Yaliyopatikana Ukurasa wa Yaliyopatikana maudhui kwa SharpSite ni mfumo wa usimamizi wa yaliyomo wa chanzo wazi uliojengwa na C# na Blazor.</value>
-  </data>
-  <data name="sharpsite_CustomizePageNotFoundDescription" xml:space="preserve">
-    <value xml:space="preserve">Mbadilishe maudhui ya ukurasa wa "ukurasa haujapatikana" kulingana na mahitaji yako.</value>
-  </data>
-  <data name="sharpsite_ChangeTheme">
-    <value xml:space="preserve">Badili Mandhari</value>
-  </data>
   <data name="sharpsite_language_label" xml:space="preserve">
     <value>Lugha</value>
     <comment>AI generated translation</comment>
@@ -363,5 +354,26 @@
   <data name="sharpsite_langauge_help_text" xml:space="preserve">
     <value>Hii hufanya teknolojia za msaada kutumia lugha sahihi kwa maudhui.</value>
     <comment>AI generated translation</comment>
+  </data>
+  <data name="sharpsite_CustomizePageNotFoundHeader" xml:space="preserve">
+    <value>Sawazisha Yaliyopatikana Ukurasa wa Yaliyopatikana maudhui kwa SharpSite ni mfumo wa usimamizi wa yaliyomo wa chanzo wazi uliojengwa na C# na Blazor.</value>
+  </data>
+  <data name="sharpsite_CustomizePageNotFoundDescription" xml:space="preserve">
+    <value>Mbadilishe maudhui ya ukurasa wa "ukurasa haujapatikana" kulingana na mahitaji yako.</value>
+  </data>
+  <data name="sharpsite_ChangeTheme" xml:space="preserve">
+    <value>Badili Mandhari</value>
+  </data>
+  <data name="sharpsite_script_alert_page" xml:space="preserve">
+    <value />
+  </data>
+  <data name="sharpsite_script_alert_post" xml:space="preserve">
+    <value />
+  </data>
+  <data name="sharpsite_confirm" xml:space="preserve">
+    <value />
+  </data>
+  <data name="sharpsite_cancel" xml:space="preserve">
+    <value />
   </data>
 </root>

--- a/src/SharpSite.Web/MarkdownHelper.cs
+++ b/src/SharpSite.Web/MarkdownHelper.cs
@@ -1,0 +1,33 @@
+﻿using System.Text.RegularExpressions;
+
+namespace SharpSite.Web;
+
+public static partial class MarkdownHelper
+{
+	/// <summary>
+	/// Checks if the markdown contains script tags outside of inline code or code blocks.
+	/// </summary>
+	/// <param name="markdown">The markdown to check.</param>
+	/// <returns></returns>
+	public static bool ContainsScriptTag(string markdown)
+	{
+
+		markdown = CodeBlockRegex().Replace(markdown, string.Empty);
+		markdown = InlineCodeRegex().Replace(markdown, string.Empty);
+
+		bool containsOpeningScriptTag = ScriptTagOpeningRegex().IsMatch(markdown);
+		bool containsClosingScriptTag = markdown.Contains("</script>", StringComparison.OrdinalIgnoreCase);
+		return containsOpeningScriptTag && containsClosingScriptTag;
+
+	}
+
+	[GeneratedRegex(@"<script\b[^>]*>", RegexOptions.IgnoreCase)]
+	private static partial Regex ScriptTagOpeningRegex();
+
+	[GeneratedRegex(@"```[\s\S]*?```")]
+	private static partial Regex CodeBlockRegex();
+
+	[GeneratedRegex(@"`[^`]*`")]
+	private static partial Regex InlineCodeRegex();
+}
+

--- a/tests/SharpSite.Tests.Web/MarkdownHelper/ContainsScriptTag.cs
+++ b/tests/SharpSite.Tests.Web/MarkdownHelper/ContainsScriptTag.cs
@@ -1,0 +1,48 @@
+﻿using Xunit;
+
+namespace SharpSite.Tests.Web.MarkdownHelper;
+
+public class ContainsScriptTag
+{
+
+    [Theory]
+    [InlineData("<script src='test.js'></script>")]
+    [InlineData("<script src='https://cdn.example.com/script.js'></script>")]
+    [InlineData("<SCRIPT>alert('test')</SCRIPT>")]
+    [InlineData("<script>\nvar x = 1;\n</script>")]
+    [InlineData("Text before <script>code</script> text after")]
+    [InlineData("<div><script>test</script></div>")]
+    [InlineData("<script type=\"text/javascript\">code</script>")]
+    [InlineData("<SCRIPT language='JavaScript'>code</SCRIPT>")]
+    [InlineData("Text\n<script>code</script>\nMore text")]
+    public void WithValidScriptTagsReturnsTrue(string markdown)
+    {
+        Assert.True(SharpSite.Web.MarkdownHelper.ContainsScriptTag(markdown));
+    }
+
+	[Theory]
+	[InlineData("```html\n<script>alert('test')</script>\n```")]
+	[InlineData("`const script = '<script></script>'`")]
+	[InlineData("<scrip>not a script tag</scrip>")]
+	[InlineData("<script>incomplete tag")]
+	[InlineData("incomplete tag </script>")]
+	[InlineData("```js\nlet script = document.createElement('script');\n```")]
+	[InlineData("`<script>`")]
+	[InlineData("```\n<script>test</script>\n<script>test2</script>\n```")]
+	[InlineData("<script-custom>not a real script tag</script-custom>")]
+	public void WithInvalidOrEscapedScriptTagsReturnsFalse(string markdown)
+	{
+		Assert.False(SharpSite.Web.MarkdownHelper.ContainsScriptTag(markdown));
+	}
+
+	[Theory]
+	[InlineData("# Just Markdown")]
+	[InlineData("Just text")]
+	[InlineData("## Script Documentation\nThis is about scripts")]
+	[InlineData("*italic* **bold** [link](https://test.com)")]
+	public void WithJustValidMarkdownReturnsFalse(string markdown)
+	{
+		Assert.False(SharpSite.Web.MarkdownHelper.ContainsScriptTag(markdown));
+	}
+
+}


### PR DESCRIPTION
If we detect a valid script tag after clicking save on a Post/Page, there is not an extra step to confirm the save action.

![image](https://github.com/user-attachments/assets/b8a4e0b8-2ac8-42b9-92e0-971df323bee4)

fix FritzAndFriends/SharpSite#219