### PR TITLE
RFC: Add extensions.json for Visual Studio Code extension recommendations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,6 +4,7 @@
 
 	// List of extensions which should be recommended for users of this workspace.
 	"recommendations": [
+		"ms-dotnettools.csdevkit",
 	],
 	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
 	"unwantedRecommendations": [

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -5,6 +5,7 @@
 	// List of extensions which should be recommended for users of this workspace.
 	"recommendations": [
 		"editorconfig.editorconfig",
+		"github.vscode-github-actions",
 		"ms-dotnettools.csdevkit",
 	],
 	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -7,6 +7,7 @@
 		"editorconfig.editorconfig",
 		"github.vscode-github-actions",
 		"ms-dotnettools.csdevkit",
+		"ms-vscode.powershell",
 	],
 	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
 	"unwantedRecommendations": [

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,6 +4,7 @@
 
 	// List of extensions which should be recommended for users of this workspace.
 	"recommendations": [
+		"editorconfig.editorconfig",
 		"ms-dotnettools.csdevkit",
 	],
 	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,12 @@
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+
+	// List of extensions which should be recommended for users of this workspace.
+	"recommendations": [
+	],
+	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+	"unwantedRecommendations": [
+		
+	],
+}


### PR DESCRIPTION
Created as a draft PR to gather feedback on whether we should do this and, if we do want this, to decide upon the most appropriate extensions to recommend when people open the project in VSCode.

Currently recommended are:
[x] C# Dev Kit
[x] Editorconfig
[x] GitHub Actions
[x] PowerShell

I have purposely added each in a separate commit so that it is easier to pick and choose which are to be merged (if any) in the project.